### PR TITLE
CVSB-4924 Updated API specs to cover ADR details

### DIFF
--- a/@Types/ITechRecord.d.ts
+++ b/@Types/ITechRecord.d.ts
@@ -1,3 +1,5 @@
+import { PERMITTED_DANGEROUS_GOODS, MEMOS_APPLY, SUBSTANCES_PERMITTED } from './../src/assets/Enums';
+
 export default interface ITechRecord {
     createdAt: string;
     lastUpdatedAt: string;
@@ -57,6 +59,8 @@ export default interface ITechRecord {
     }
 };
     axles: Axle[];
+    euroStandard?: string;
+    adrDetails?: AdrDetails;
 }
 
 interface Axle {
@@ -76,4 +80,56 @@ interface Axle {
         speedCategorySymbol: string,
         tyreCode: number
     };
+}
+
+export interface AdrDetails {
+    vehicleDetails: VehicleDetails;
+    permittedDangerousGoods: PERMITTED_DANGEROUS_GOODS[];
+    additionalExaminerNotes: string;
+    applicantDetails: ApplicantDetails;
+    memosApply: MEMOS_APPLY[];
+    additionalNotes: AdditionalNotes;
+    tank: Tank;
+}
+
+export interface AdditionalNotes {
+    number: number;
+    guidanceNotes: string[];
+}
+
+export interface ApplicantDetails {
+    name: string;
+    street: string;
+    town: string;
+    city: string;
+    postcode: string;
+}
+
+export interface Tank {
+    tankDetails: TankDetails;
+    tankStatement: TankStatement;
+}
+
+export interface TankDetails {
+    tankManufacturer: string;
+    tc2IntermediateApprovalNo: string;
+    tc2IntermediateExpiryDate: Date;
+    tc3PeriodicNumber: string;
+    tc3PeriodicExpiryDate: Date;
+    yearOfManufacture: string;
+    tankCode: string;
+    specialProvisions: string;
+    tankManufacturerSerialNo: string;
+    tankTypeAppNo: string;
+}
+
+export interface TankStatement {
+    substancesPermitted: SUBSTANCES_PERMITTED;
+    statement: string | null; // statement and productList are mutually exclusive
+    productList: string | null;
+}
+
+export interface VehicleDetails {
+    type: string;
+    approvalDate: Date;
 }

--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -19,3 +19,31 @@ export enum STATUS {
     PROVISIONAL_OVER_CURRENT = "provisional_over_current",
     ALL = "all"
 }
+
+export enum PERMITTED_DANGEROUS_GOODS {
+    "FP <61 (FL)",
+    "AT",
+    "Class 5.1 Hydrogen Peroxide (OX)",
+    "MEMU",
+    "Carbon Disulphide",
+    "Hydrogen",
+    "Explosives: Type 2",
+    "Explosives: Type 3",
+}
+
+export enum SUBSTANCES_PERMITTED {
+    "Substances permitted under the tank code and any special provisions specified in 9 may be carried",
+    "Substances (Class UN number and if necessary packing group and proper shipping name) may be carried",
+}
+
+export enum MEMOS_APPLY {
+    "07/09 3mth leak ext",
+    "03/10 vehicle ABS/EBS",
+    "03/10 trailer ABS",
+}
+
+export enum GUIDANCE_NOTES {
+    "M145 Statement",
+    "M129 Statement",
+    "New certificate requested",
+}

--- a/src/services/TechRecordsService.ts
+++ b/src/services/TechRecordsService.ts
@@ -88,6 +88,12 @@ class TechRecordsService {
     delete techRecordItem.secondaryVrms; // No longer needed
     delete techRecordItem.partialVin; // No longer needed
 
+    techRecordItem.techRecord.forEach((techRecord) => {
+      if (techRecord.euroStandard !== undefined && techRecord.euroStandard !== null) {
+        techRecord.euroStandard = techRecord.euroStandard.toString();
+      }
+    });
+
     return techRecordItem;
   }
 

--- a/tests/features/4924.ACs.feature
+++ b/tests/features/4924.ACs.feature
@@ -1,0 +1,20 @@
+Feature: Iteration on technical records API specs to cover ADR details
+
+  Scenario: AC1 API Consumer retrieve the Vehicle Technical Records
+    Given I am an API Consumer
+    When I send a request to AWS_CVS_DOMAIN/vehicles/{searchIdentifier}/tech-records
+    And there is a vehicle that can be identified by the value provided for the searchIdentifier
+    Then the system returns a body message containing a single CompleteTechRecord
+    And the system returns an HTTP status code 200 OK
+
+  Scenario: AC2 No data returned
+    Given I am an API Consumer
+    When I send a request to AWS_CVS_DOMAIN/vehicles/{searchIdentifier}/tech-records
+    And no data is found
+    Then the system returns an HTTP status code 404
+
+  Scenario: AC3 Multiple results returned
+    Given I am an API Consumer
+    When I send a request to AWS_CVS_DOMAIN/vehicles/{searchIdentifier}/tech-records
+    And multiple results found (more than one CompleteTechRecord object is returned)
+    Then the system returns an HTTP status code 422

--- a/tests/features/step_definitions/4924.ACs.feature.steps.intTest.ts
+++ b/tests/features/step_definitions/4924.ACs.feature.steps.intTest.ts
@@ -1,0 +1,97 @@
+import { convertToResponse } from './../../util/dbOperations';
+import { defineFeature, loadFeature } from 'jest-cucumber';
+import supertest from "supertest";
+import path from 'path';
+import { emptyDatabase, populateDatabase } from "../../util/dbOperations";
+import mockData from "../../resources/technical-records.json";
+import { cloneDeep } from "lodash";
+import mockContext from "aws-lambda-mock-context";
+import ITechRecord from '../../../@Types/ITechRecord';
+
+const url = "http://localhost:3005/";
+const request = supertest(url);
+const opts = Object.assign({
+  timeout: 0.5
+});
+const feature = loadFeature(path.resolve(__dirname, "../4924.ACs.feature"));
+
+defineFeature(feature, test => {
+  beforeAll(async () => {
+    await emptyDatabase();
+  });
+
+  beforeEach(async () => {
+    await populateDatabase();
+  });
+
+  afterEach(async () => {
+    await emptyDatabase();
+  });
+
+  afterAll(async () => {
+    await populateDatabase();
+  });
+
+  let ctx: any = mockContext(opts);
+
+
+  test('AC1 API Consumer retrieve the Vehicle Technical Records', ({ given, when, then, and }) => {
+    let requestUrl: string;
+    let response: any;
+    let expectedResponse: any;
+
+    given('I am an API Consumer', () => {
+      requestUrl = 'vehicles/012999/tech-records';
+    });
+    when('I send a request to AWS_CVS_DOMAIN/vehicles/{searchIdentifier}/tech-records', async () => {
+      response = await request.get(requestUrl);
+    });
+    and('there is a vehicle that can be identified by the value provided for the searchIdentifier', () => {
+      expectedResponse = convertToResponse(cloneDeep(mockData[29]));
+    });
+    then('the system returns a body message containing a single CompleteTechRecord', () => {
+      expect(expectedResponse).toEqual(response.body);
+      let techRecord: ITechRecord[] = response.body.techRecord;
+      expect(techRecord[0].adrDetails).toBeTruthy();
+    });
+    and('the system returns an HTTP status code 200 OK', () => {
+      expect(response.status).toEqual(200);
+    });
+  });
+
+  test('AC2 No data returned', ({ given, when, then, and }) => {
+    let requestUrl: string;
+    let response: any;
+    given('I am an API Consumer', () => {
+      requestUrl = 'vehicles/T72745555/tech-records';
+    });
+    when('I send a request to AWS_CVS_DOMAIN/vehicles/{searchIdentifier}/tech-records', async () => {
+      response = await request.get(requestUrl);
+    });
+    and('no data is found', () => {
+    });
+    then('the system returns an HTTP status code 404', () => {
+      expect(response.status).toEqual(404);
+    });
+  });
+
+  test('AC3 Multiple results returned', ({ given, when, then, and }) => {
+    let requestUrl: string;
+    let response: any;
+    given('I am an API Consumer', () => {
+      requestUrl = 'vehicles/678413/tech-records';
+    });
+    when('I send a request to AWS_CVS_DOMAIN/vehicles/{searchIdentifier}/tech-records', async () => {
+      response = await request.get(requestUrl);
+    });
+    and('multiple results found (more than one CompleteTechRecord object is returned)', () => {
+    });
+    then('the system returns an HTTP status code 422', () => {
+      expect(response.status).toEqual(422);
+    });
+  });
+
+
+  ctx.succeed('done');
+  ctx = null;
+});

--- a/tests/resources/technical-records.json
+++ b/tests/resources/technical-records.json
@@ -2774,7 +2774,7 @@
         "tyreUseCode": "2B",
         "roadFriendly": true,
         "drawbarCouplingFitted": true,
-        "euroStandard": 7,
+        "euroStandard": "7",
         "dimensions": {
           "length": 7500,
           "width": 2200
@@ -3359,7 +3359,7 @@
           "width": 2200
         },
         "drawbarCouplingFitted": true,
-        "euroStandard": 7,
+        "euroStandard": "7",
         "frontAxleTo5thWheelCouplingMax": 1900,
         "frontAxleTo5thWheelCouplingMin": 1700,
         "frontAxleTo5thWheelMax": 1500,
@@ -3499,7 +3499,7 @@
           "width": 2200
         },
         "drawbarCouplingFitted": true,
-        "euroStandard": 7,
+        "euroStandard": "7",
         "frontAxleTo5thWheelCouplingMax": 1900,
         "frontAxleTo5thWheelCouplingMin": 1700,
         "frontAxleTo5thWheelMax": 1500,
@@ -3977,7 +3977,7 @@
           "width": 2200
         },
         "drawbarCouplingFitted": true,
-        "euroStandard": 7,
+        "euroStandard": "7",
         "frontAxleTo5thWheelCouplingMax": 1900,
         "frontAxleTo5thWheelCouplingMin": 1700,
         "frontAxleTo5thWheelMax": 1500,
@@ -4177,7 +4177,7 @@
           "width": 2200
         },
         "drawbarCouplingFitted": true,
-        "euroStandard": 7,
+        "euroStandard": "7",
         "frontAxleTo5thWheelCouplingMax": 1900,
         "frontAxleTo5thWheelCouplingMin": 1700,
         "frontAxleTo5thWheelMax": 1500,
@@ -4268,7 +4268,7 @@
           "width": 2200
         },
         "drawbarCouplingFitted": true,
-        "euroStandard": 7,
+        "euroStandard": "7",
         "frontAxleTo5thWheelCouplingMax": 1900,
         "frontAxleTo5thWheelCouplingMin": 1700,
         "frontAxleTo5thWheelMax": 1500,
@@ -4665,7 +4665,7 @@
         "tyreUseCode": "2B",
         "roadFriendly": true,
         "drawbarCouplingFitted": true,
-        "euroStandard": 7,
+        "euroStandard": "7",
         "dimensions": {
           "length": 7500,
           "width": 2200
@@ -4813,7 +4813,7 @@
           "width": 2200
         },
         "drawbarCouplingFitted": true,
-        "euroStandard": 7,
+        "euroStandard": "7",
         "frontAxleTo5thWheelCouplingMax": 1900,
         "frontAxleTo5thWheelCouplingMin": 1700,
         "frontAxleTo5thWheelMax": 1500,
@@ -4913,7 +4913,7 @@
           "width": 2200
         },
         "drawbarCouplingFitted": true,
-        "euroStandard": 7,
+        "euroStandard": "7",
         "frontAxleTo5thWheelCouplingMax": 1900,
         "frontAxleTo5thWheelCouplingMin": 1700,
         "frontAxleTo5thWheelMax": 1500,
@@ -5312,7 +5312,7 @@
           "width": 2200
         },
         "drawbarCouplingFitted": true,
-        "euroStandard": 7,
+        "euroStandard": 0,
         "frontAxleTo5thWheelCouplingMax": 1900,
         "frontAxleTo5thWheelCouplingMin": 1700,
         "frontAxleTo5thWheelMax": 1500,

--- a/tests/resources/technical-records.json
+++ b/tests/resources/technical-records.json
@@ -5177,5 +5177,175 @@
     ],
     "trailerId": "C100002",
     "vin": "T72741999"
-  } 
+  },
+  {
+    "partialVin": "012999",
+    "primaryVrm": "HG999HG",
+    "secondaryVrms": [
+      "HG999HGV"
+    ],
+    "techRecord": [
+      {
+        "brakes": {
+          "brakeCodeOriginal": "12412",
+          "brakeCode": "123",
+          "dataTrBrakeOne": "None",
+          "dataTrBrakeTwo": "None",
+          "dataTrBrakeThree": "None",
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "exhaust",
+          "dtpNumber": "sdgs",
+          "brakeForceWheelsNotLocked": {
+            "serviceBrakeForceA": 6424,
+            "secondaryBrakeForceA": 2512,
+            "parkingBrakeForceA": 2332
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "serviceBrakeForceB": 5521,
+            "secondaryBrakeForceB": 2512,
+            "parkingBrakeForceB": 3512
+          },
+          "loadSensingValve": true,
+          "antilockBrakingSystem": true
+        },
+        "axles": [
+          {
+            "axleNumber": 1,
+            "tyres": {
+              "dataTrAxles": 345,
+              "fitmentCode": "single",
+              "plyRating": "AB",
+              "speedCategorySymbol": "a7",
+              "tyreCode": 1234,
+              "tyreSize": "9.23648E+11"
+            },
+            "weights": {
+              "designWeight": 1800,
+              "gbWeight": 1400
+            }
+          },
+          {
+            "axleNumber": 2,
+            "tyres": {
+              "dataTrAxles": 345,
+              "fitmentCode": "single",
+              "plyRating": "AB",
+              "speedCategorySymbol": "a7",
+              "tyreCode": 5678,
+              "tyreSize": "9.23648E+11"
+            },
+            "weights": {
+              "designWeight": 1900,
+              "gbWeight": 1600
+            }
+          },
+          {
+            "axleNumber": 3,
+            "tyres": {
+              "dataTrAxles": 345,
+              "fitmentCode": "single",
+              "plyRating": "AB",
+              "speedCategorySymbol": "a7",
+              "tyreCode": 5678,
+              "tyreSize": "9.23648E+11"
+            },
+            "weights": {
+              "designWeight": 1900,
+              "gbWeight": 1600
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "t",
+          "description": "tipper"
+        },
+        "brakeCode": "178202",
+        "adrDetails": {
+          "vehicleDetails": {
+            "type": "string",
+            "approvalDate": "2019-10-01"
+          },
+          "permittedDangerousGoods": [
+            "FP <61 (FL)"
+          ],
+          "additionalExaminerNotes": "string",
+          "applicantDetails": {
+            "name": "string",
+            "street": "string",
+            "town": "string",
+            "city": "string",
+            "postcode": "string"
+          },
+          "memosApply": [
+            "07/09 3mth leak ext"
+          ],
+          "additionalNotes": {
+            "number": 0,
+            "guidanceNotes": [
+              "M145 Statement"
+            ]
+          },
+          "tank": {
+            "tankDetails": {
+              "tankManufacturer": "string",
+              "tc2IntermediateApprovalNo": "string",
+              "tc2IntermediateExpiryDate": "2019-10-01",
+              "tc3PeriodicNumber": "string",
+              "tc3PeriodicExpiryDate": "2019-10-01",
+              "yearOfManufacture": "string",
+              "tankCode": "string",
+              "specialProvisions": "string",
+              "tankManufacturerSerialNo": "string",
+              "tankTypeAppNo": "string"
+            },
+            "tankStatement": {
+              "substancesPermitted": "Substances permitted under the tank code and any special provisions specified in 9 may be carried",
+              "statement": "string",
+              "productList": "string"
+            }
+          }
+        },
+        "conversionRefNo": "7891234",
+        "createdAt": "2019-06-24T10:26:54.903Z",
+        "dimensions": {
+          "length": 7500,
+          "width": 2200
+        },
+        "drawbarCouplingFitted": true,
+        "euroStandard": 7,
+        "frontAxleTo5thWheelCouplingMax": 1900,
+        "frontAxleTo5thWheelCouplingMin": 1700,
+        "frontAxleTo5thWheelMax": 1500,
+        "frontAxleTo5thWheelMin": 1200,
+        "functionCode": "A",
+        "grossKerbWeight": 2500,
+        "grossLadenWeight": 3000,
+        "lastUpdatedAt": "2019-06-24T10:26:54.903Z",
+        "make": "Isuzu",
+        "manufactureYear": 2018,
+        "maxTrainDesignWeight": 500,
+        "maxTrainGbWeight": 1000,
+        "model": "FM",
+        "noOfAxles": 3,
+        "notes": "test note",
+        "ntaNumber": "123456",
+        "reasonForCreation": "new vehicle",
+        "regnDate": "2019-06-24",
+        "roadFriendly": true,
+        "speedLimiterMrk": true,
+        "statusCode": "current",
+        "tachoExemptMrk": true,
+        "trainDesignWeight": 2000,
+        "trainGbWeight": 1500,
+        "tyreUseCode": "2B",
+        "vehicleType": "hgv",
+        "vehicleClass": {
+          "code": "v",
+          "description": "heavy goods vehicle"
+        },
+        "vehicleConfiguration": "full drawbar"
+      }
+    ],
+    "vin": "P012301012938"
+  }
 ]

--- a/tests/unit/TechRecordsService.unitTest.ts
+++ b/tests/unit/TechRecordsService.unitTest.ts
@@ -334,5 +334,26 @@ describe("updateTechRecord", () => {
       }
     });
   });
+
+  it("should return euroStandard as a string, even if the field is set as 0 in dynamodb", async () => {
+    const MockDAO = jest.fn().mockImplementation(() => {
+      return {
+        getBySearchTerm: () => {
+          return Promise.resolve({
+            Items: [records[29]],
+            Count: 1,
+            ScannedCount: 1
+          });
+        }
+      };
+    });
+    const mockDAO = new MockDAO();
+    const techRecordsService = new TechRecordsService(mockDAO);
+
+    const returnedRecords = await techRecordsService.getTechRecordsList("P012301012938", STATUS.PROVISIONAL_OVER_CURRENT);
+    expect(typeof returnedRecords.techRecord[0].euroStandard).toBe("string");
+    expect(returnedRecords.techRecord[0].euroStandard).toBe("0");
+  });
+
 });
 

--- a/tests/unit/insertTechRecordsList.unitTest.ts
+++ b/tests/unit/insertTechRecordsList.unitTest.ts
@@ -24,7 +24,7 @@ describe("insertTechRecordsList", () => {
 
       // @ts-ignore
       const data: ITechRecord[] = await techRecordsService.insertTechRecordsList(records);
-      expect(data.length).toEqual(29);
+      expect(data.length).toEqual(30);
     });
 
     it("should return nothing", async () => {

--- a/tests/util/dbOperations.ts
+++ b/tests/util/dbOperations.ts
@@ -45,6 +45,12 @@ export const convertToResponse = (dbObj: any) => { // Needed to convert an objec
     delete responseObj.secondaryVrms; // No longer needed
     delete responseObj.partialVin; // No longer needed
 
+    responseObj.techRecord.forEach((techRecord: any) => {
+        if (techRecord.euroStandard !== undefined && techRecord.euroStandard !== null) {
+          techRecord.euroStandard = techRecord.euroStandard.toString();
+        }
+      });
+
     return responseObj;
 };
 


### PR DESCRIPTION
I branched this change from CVSB-7885 to retrieve the jest-cucumber setup.
Redundant integration tests were copied as per guidelines.