### PR TITLE
Feature/cvsb 9657

### DIFF
--- a/src/services/TechRecordsService.ts
+++ b/src/services/TechRecordsService.ts
@@ -105,6 +105,20 @@ class TechRecordsService {
       if (techRecord.euroStandard !== undefined && techRecord.euroStandard !== null) {
         techRecord.euroStandard = techRecord.euroStandard.toString();
       }
+      if (techRecord.adrDetails) {
+        if (techRecord.adrDetails.documents) {
+          techRecord.adrDetails.documents = techRecord.adrDetails.documents.map((document: string) => {
+            const filename = document.split("/");
+            if (filename.length > 1) {
+              return document.split("/")[1];
+            } else {
+              return filename[0];
+            }
+          });
+        } else {
+          techRecord.adrDetails.documents = [];
+        }
+      }
     });
 
     return techRecordItem;
@@ -131,7 +145,8 @@ class TechRecordsService {
           const documents: string[] = [];
           if (uploadedData && uploadedData.length) {
             for (const uploaded of uploadedData) {
-              documents.push(uploaded.Key);
+              const filename = uploaded.Key.split("/")[1];
+              documents.push(filename);
             }
           } else {
             throw new HTTPError(500, HTTPRESPONSE.S3_ERROR);

--- a/tests/util/dbOperations.ts
+++ b/tests/util/dbOperations.ts
@@ -53,6 +53,20 @@ export const convertToResponse = (dbObj: any) => { // Needed to convert an objec
         if (techRecord.euroStandard !== undefined && techRecord.euroStandard !== null) {
           techRecord.euroStandard = techRecord.euroStandard.toString();
         }
+        if (techRecord.adrDetails) {
+            if (techRecord.adrDetails.documents) {
+                techRecord.adrDetails.documents = techRecord.adrDetails.documents.map((document: string) => {
+                    const filename = document.split("/");
+                    if (filename.length > 1) {
+                        return document.split("/")[1];
+                    } else {
+                        return filename[0];
+                    }
+                });
+            } else {
+                techRecord.adrDetails.documents = [];
+            }
+        }
       });
 
     return responseObj;


### PR DESCRIPTION
1. documents[] array to be returned even if there are no documents uploaded for that tech-record
2. documents[] array will contain only the filename, without the name of the branch appended (currently when a document is uploaded, the filename is generated as "CVSB-YYYY/uuid.pdf")