### PR TITLE
feature/CVSB-10316 - update statusCode after firstTest/notifiable alt

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -135,8 +135,8 @@ functions:
     handler: src/handler.handler
     events:
       - http:
-          path: vehicles/{systemNumber}
-          method: post
+          path: vehicles/update-status/{systemNumber}
+          method: put
           request:
             parameters:
               paths:

--- a/src/functions/updateTechRecordStatus.ts
+++ b/src/functions/updateTechRecordStatus.ts
@@ -11,12 +11,14 @@ export async function updateTechRecordStatus(event: any) {
     const testResult: string = event.queryStringParameters!.testResult;
     const testTypeId: string = event.queryStringParameters!.testTypeId;
     const newStatus = event.queryStringParameters ? STATUS[event.queryStringParameters.newStatus as keyof typeof STATUS] : undefined;
+    const createdById: string = event.queryStringParameters!.createdById;
+    const createdByName: string = event.queryStringParameters!.createdByName;
 
     if (!TechRecordsService.isStatusUpdateRequired(testStatus, testResult, testTypeId)) {
         return new HTTPResponse(200, HTTPRESPONSE.NO_STATUS_UPDATE_REQUIRED);
     }
     try {
-        const updatedTechRec = await techRecordsService.updateTechRecordStatusCode(systemNumber, newStatus );
+        const updatedTechRec = await techRecordsService.updateTechRecordStatusCode(systemNumber, newStatus, createdById, createdByName);
         return new HTTPResponse(200, updatedTechRec);
     } catch (error) {
         return new HTTPResponse(error.statusCode, error.body);

--- a/tests/integration/updateTechRecordStatus.intTest.ts
+++ b/tests/integration/updateTechRecordStatus.intTest.ts
@@ -24,13 +24,13 @@ describe("UpdateTechRecordStatus", () => {
 
     context("when trying to update a vehicle", () => {
         it("should not update the status if the test type does not require a tech record update", async () => {
-            const vin: string = "P012301270123";
+            const systemNumber: string = "11000001";
             expect.assertions(2);
             await LambdaTester(updateTechRecordStatus)
                 .event({
-                    path: "/vehicles/update-status/" + vin,
+                    path: "/vehicles/update-status/" + systemNumber,
                     pathParameters: {
-                        vin,
+                      systemNumber,
                     },
                     queryStringParameters: {
                         testStatus: "submitted",
@@ -38,7 +38,7 @@ describe("UpdateTechRecordStatus", () => {
                         testTypeId: "1",
                     },
                     httpMethod: "PUT",
-                    resource: "/vehicles/update-status/{vin}"
+                    resource: "/vehicles/update-status/{systemNumber}"
                 })
                 .expectResolve((result: any) => {
                     expect(result.statusCode).toBe(200);
@@ -61,7 +61,7 @@ describe("UpdateTechRecordStatus", () => {
                         testTypeId: "47",
                     },
                     httpMethod: "PUT",
-                    resource: "/vehicles/update-status/{vin}"
+                    resource: "/vehicles/update-status/{systemNumber}"
                 })
                 .expectResolve((result: any) => {
                     expect(result.statusCode).toBe(200);
@@ -73,7 +73,7 @@ describe("UpdateTechRecordStatus", () => {
         });
 
         it("should return 400 if the vehicle status cannot be updated", async () => {
-            const systemNumber: string = "11000013";
+            const systemNumber: string = "11000032";
             expect.assertions(2);
             await LambdaTester(updateTechRecordStatus)
                 .event({
@@ -87,7 +87,7 @@ describe("UpdateTechRecordStatus", () => {
                         testTypeId: "47",
                     },
                     httpMethod: "PUT",
-                    resource: "/vehicles/update-status/{vin}"
+                    resource: "/vehicles/update-status/{systemNumber}"
                 })
                 .expectResolve((result: any) => {
                     expect(result.statusCode).toBe(400);
@@ -110,7 +110,7 @@ describe("UpdateTechRecordStatus", () => {
                         testTypeId: "47",
                     },
                     httpMethod: "PUT",
-                    resource: "/vehicles/update-status/{vin}"
+                    resource: "/vehicles/update-status/{systemNumber}"
                 })
                 .expectResolve((result: any) => {
                     expect(result.statusCode).toBe(404);

--- a/tests/unit/TechRecordsService.unitTest.ts
+++ b/tests/unit/TechRecordsService.unitTest.ts
@@ -2,7 +2,7 @@
 import TechRecordsService from "../../src/services/TechRecordsService";
 import HTTPError from "../../src/models/HTTPError";
 import records from "../resources/technical-records.json";
-import {HTTPRESPONSE, SEARCHCRITERIA, STATUS, EU_VEHICLE_CATEGORY, ERRORS} from "../../src/assets/Enums";
+import {HTTPRESPONSE, SEARCHCRITERIA, STATUS, EU_VEHICLE_CATEGORY, ERRORS, UPDATE_TYPE} from "../../src/assets/Enums";
 import ITechRecordWrapper from "../../@Types/ITechRecordWrapper";
 import {cloneDeep} from "lodash";
 import HTTPResponse from "../../src/models/HTTPResponse";
@@ -1352,3 +1352,116 @@ describe("archiveTechRecordStatus", () => {
   });
 });
 
+
+describe("updateTechRecordStatus", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  const createdByName = "dorel";
+  const createdById = "1234";
+
+  context("when updating the statusCode for an existing vehicle", () => {
+    context("and the vehicle has only a current tech record", () => {
+      it("should create new CURRENT, set the audit details and archive the previous current record", async () => {
+        const existingTechRecord = cloneDeep(records[0]);
+        const systemNumber = existingTechRecord.systemNumber;
+        const MockDAO = jest.fn().mockImplementation(() => {
+          return {
+            getBySearchTerm: () => {
+              return Promise.resolve({
+                Items: [existingTechRecord],
+                Count: 1,
+                ScannedCount: 1
+              });
+            }
+          };
+        });
+        expect.assertions(11);
+        const mockDAO = new MockDAO();
+        const techRecordsService = new TechRecordsService(mockDAO);
+        const updatedTechRec: ITechRecordWrapper = await techRecordsService.prepareTechRecordForStatusUpdate(systemNumber, undefined, createdById, createdByName);
+        expect(updatedTechRec.techRecord.length).toEqual(2);
+        expect(updatedTechRec.techRecord[1].createdById).toEqual(createdById);
+        expect(updatedTechRec.techRecord[1].createdByName).toEqual(createdByName);
+        expect(updatedTechRec.techRecord[1].statusCode).toEqual(STATUS.CURRENT);
+        expect(updatedTechRec.techRecord[1]).not.toHaveProperty("lastUpdatedAt");
+        expect(updatedTechRec.techRecord[1]).not.toHaveProperty("lastUpdatedByName");
+        expect(updatedTechRec.techRecord[1]).not.toHaveProperty("lastUpdatedById");
+        expect(updatedTechRec.techRecord[0].lastUpdatedById).toEqual(createdById);
+        expect(updatedTechRec.techRecord[0].lastUpdatedByName).toEqual(createdByName);
+        expect(updatedTechRec.techRecord[0].statusCode).toEqual(STATUS.ARCHIVED);
+        expect(updatedTechRec.techRecord[0].updateType).toEqual(UPDATE_TYPE.TECH_RECORD_UPDATE);
+      });
+    });
+
+    context("and the vehicle has only a provisional tech record", () => {
+      it("should create new CURRENT, set the audit details and archive the previous provisional record", async () => {
+        const existingTechRecord = cloneDeep(records[3]);
+        const systemNumber = existingTechRecord.systemNumber;
+        const MockDAO = jest.fn().mockImplementation(() => {
+          return {
+            getBySearchTerm: () => {
+              return Promise.resolve({
+                Items: [existingTechRecord],
+                Count: 1,
+                ScannedCount: 1
+              });
+            }
+          };
+        });
+        expect.assertions(11);
+        const mockDAO = new MockDAO();
+        const techRecordsService = new TechRecordsService(mockDAO);
+        const updatedTechRec: ITechRecordWrapper = await techRecordsService.prepareTechRecordForStatusUpdate(systemNumber, undefined, createdById, createdByName);
+        expect(updatedTechRec.techRecord.length).toEqual(2);
+        expect(updatedTechRec.techRecord[1].createdById).toEqual(createdById);
+        expect(updatedTechRec.techRecord[1].createdByName).toEqual(createdByName);
+        expect(updatedTechRec.techRecord[1].statusCode).toEqual(STATUS.CURRENT);
+        expect(updatedTechRec.techRecord[1]).not.toHaveProperty("lastUpdatedAt");
+        expect(updatedTechRec.techRecord[1]).not.toHaveProperty("lastUpdatedByName");
+        expect(updatedTechRec.techRecord[1]).not.toHaveProperty("lastUpdatedById");
+        expect(updatedTechRec.techRecord[0].lastUpdatedById).toEqual(createdById);
+        expect(updatedTechRec.techRecord[0].lastUpdatedByName).toEqual(createdByName);
+        expect(updatedTechRec.techRecord[0].statusCode).toEqual(STATUS.ARCHIVED);
+        expect(updatedTechRec.techRecord[0].updateType).toEqual(UPDATE_TYPE.TECH_RECORD_UPDATE);
+      });
+    });
+
+    context("and the vehicle has a current and a provisional record", () => {
+      it("should create new CURRENT, set the audit details and archive the previous current and provisional record", async () => {
+        const existingTechRecord = cloneDeep(records[44]);
+        const systemNumber = existingTechRecord.systemNumber;
+        const MockDAO = jest.fn().mockImplementation(() => {
+          return {
+            getBySearchTerm: () => {
+              return Promise.resolve({
+                Items: [existingTechRecord],
+                Count: 1,
+                ScannedCount: 1
+              });
+            }
+          };
+        });
+        expect.assertions(15);
+        const mockDAO = new MockDAO();
+        const techRecordsService = new TechRecordsService(mockDAO);
+        const updatedTechRec: ITechRecordWrapper = await techRecordsService.prepareTechRecordForStatusUpdate(systemNumber, undefined, createdById, createdByName);
+        expect(updatedTechRec.techRecord.length).toEqual(3);
+        expect(updatedTechRec.techRecord[2].createdById).toEqual(createdById);
+        expect(updatedTechRec.techRecord[2].createdByName).toEqual(createdByName);
+        expect(updatedTechRec.techRecord[2].statusCode).toEqual(STATUS.CURRENT);
+        expect(updatedTechRec.techRecord[2]).not.toHaveProperty("lastUpdatedAt");
+        expect(updatedTechRec.techRecord[2]).not.toHaveProperty("lastUpdatedByName");
+        expect(updatedTechRec.techRecord[2]).not.toHaveProperty("lastUpdatedById");
+        expect(updatedTechRec.techRecord[0].lastUpdatedById).toEqual(createdById);
+        expect(updatedTechRec.techRecord[0].lastUpdatedByName).toEqual(createdByName);
+        expect(updatedTechRec.techRecord[0].updateType).toEqual(UPDATE_TYPE.TECH_RECORD_UPDATE);
+        expect(updatedTechRec.techRecord[0].statusCode).toEqual(STATUS.ARCHIVED);
+        expect(updatedTechRec.techRecord[1].lastUpdatedById).toEqual(createdById);
+        expect(updatedTechRec.techRecord[1].lastUpdatedByName).toEqual(createdByName);
+        expect(updatedTechRec.techRecord[1].updateType).toEqual(UPDATE_TYPE.TECH_RECORD_UPDATE);
+        expect(updatedTechRec.techRecord[1].statusCode).toEqual(STATUS.ARCHIVED);
+      });
+    });
+  });
+});


### PR DESCRIPTION
technical records' status to be updated from provisional to current if a vehicle passes via 'PASS' or 'PRS' for a first test/ notifiable alteration test carried out via the app or VTM (as part of a contingency process).

https://jira.dvsacloud.uk/browse/CVSB-10316