### PR TITLE
Feature/cvsb 10195 - archive, add provisional record and statusCode change

### DIFF
--- a/@Types/IUserDetails.ts
+++ b/@Types/IUserDetails.ts
@@ -1,0 +1,4 @@
+export default interface IMsUserDetails {
+    msUser: string;
+    msOid: string;
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -151,6 +151,26 @@ functions:
             parameters:
               paths:
                 systemNumber: true
+  addProvisionalTechRecord:
+    handler: src/handler.handler
+    events:
+      - http:
+          path: /vehicles/add-provisional/{systemNumber}
+          method: post
+          request:
+            parameters:
+              paths:
+                systemNumber: true
+  archiveTechRecordStatus:
+    handler: src/handler.handler
+    events:
+      - http:
+          path: /vehicles/archive/{systemNumber}
+          method: put
+          request:
+            parameters:
+              paths:
+                systemNumber: true
 
 resources:
   Resources:

--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -7,8 +7,14 @@ export enum ERRORS {
     NO_UNIQUE_RECORD = "Failed to uniquely identify record",
     TRAILER_ID_GENERATION_FAILED = "TrailerId generation failed!",
     SYSTEM_NUMBER_GENERATION_FAILED = "System Number generation failed!",
-    CANNOT_UPDATE_ARCHIVED_RECORD = "You are not allowed to update an archived tech-record"
-
+    CANNOT_UPDATE_ARCHIVED_RECORD = "You are not allowed to update an archived tech-record",
+    CANNOT_USE_UPDATE_TO_ARCHIVE = "Cannot use update API to archive tech record",
+    CANNOT_ARCHIVE_CHANGED_RECORD = "Cannot archive tech record with attribute changes",
+    CURRENT_OR_PROVISIONAL_RECORD_FOUND = "Has existing Current or Provisional record",
+    CANNOT_CHANGE_CURRENT_TO_PROVISIONAL = "Cannot change current status to provisional",
+    STATUS_CODE_SHOULD_BE_PROVISIONAL = "Status code should be provisional",
+    MISSING_PAYLOAD = "Missing payload!",
+    MISSING_USER = "Microsoft user details not provided"
 }
 
 export enum HTTPRESPONSE {
@@ -283,4 +289,10 @@ export const FRAME_DESCRIPTION: string[] = [
 export const LETTER_TYPE: string[] = [
     "Trailer authorization",
     "Trailer rejection"
+];
+
+export const STATUS_CODES: string[] = [
+    "current",
+    "provisional",
+    "archived"
 ];

--- a/src/config/config.yml
+++ b/src/config/config.yml
@@ -20,6 +20,16 @@ functions:
     method: PUT
     path: /vehicles/update-eu-vehicle-category/:systemNumber
     function: updateEuVehicleCategory
+- addProvisionalTechRecord:
+    method: POST
+    path: /vehicles/add-provisional/:systemNumber
+    proxy: :systemNumber
+    function: addProvisionalTechRecord
+- archiveTechRecordStatus:
+    method: PUT
+    path: /vehicles/archive/:systemNumber
+    proxy: :systemNumber
+    function: archiveTechRecordStatus
 
 dynamodb:
   local:

--- a/src/functions/addProvisionalTechRecord.ts
+++ b/src/functions/addProvisionalTechRecord.ts
@@ -1,0 +1,38 @@
+import TechRecordsDAO from "../models/TechRecordsDAO";
+import TechRecordsService from "../services/TechRecordsService";
+import HTTPResponse from "../models/HTTPResponse";
+import ITechRecordWrapper from "../../@Types/ITechRecordWrapper";
+import ITechRecord from "../../@Types/ITechRecord";
+import IMsUserDetails from "../../@Types/IUserDetails";
+import {formatErrorMessage} from "../utils/formatErrorMessage";
+
+const addProvisionalTechRecord = (event: any) => {
+  const techRecordsDAO = new TechRecordsDAO();
+  const techRecordsService = new TechRecordsService(techRecordsDAO);
+
+  const sysNum: string = event.pathParameters.systemNumber;
+  const techRec: ITechRecord[] = event.body ? event.body.techRecord : null;
+  const msUserDetails: IMsUserDetails = event.body ? event.body.msUserDetails : null;
+
+  if (!techRec || !techRec.length) {
+    return Promise.resolve(new HTTPResponse(400, formatErrorMessage("Body is not a valid TechRecord")));
+  }
+
+  if (!msUserDetails || !msUserDetails.msUser || !msUserDetails.msOid) {
+    return Promise.resolve(new HTTPResponse(400, formatErrorMessage("Microsoft user details not provided")));
+  }
+  const techRecord: ITechRecordWrapper = {
+    vin: "",
+    techRecord: techRec,
+    systemNumber: sysNum
+  };
+  return techRecordsService.addProvisionalTechRecord(techRecord, msUserDetails)
+    .then((addedProvisionalTechRecord: any) => {
+      return new HTTPResponse(200, addedProvisionalTechRecord);
+    })
+    .catch((error: any) => {
+      console.log(error);
+      return new HTTPResponse(error.statusCode, error.body);
+    });
+};
+export {addProvisionalTechRecord};

--- a/src/functions/archiveTechRecordStatus.ts
+++ b/src/functions/archiveTechRecordStatus.ts
@@ -1,0 +1,36 @@
+import TechRecordsDAO from "../models/TechRecordsDAO";
+import TechRecordsService from "../services/TechRecordsService";
+import HTTPResponse from "../models/HTTPResponse";
+import ITechRecordWrapper from "../../@Types/ITechRecordWrapper";
+import {ERRORS} from "../assets/Enums";
+import {formatErrorMessage} from "../utils/formatErrorMessage";
+
+export async function archiveTechRecordStatus(event: any) {
+  const techRecordsService = new TechRecordsService(new TechRecordsDAO());
+
+  const systemNumber: string = event.pathParameters!.systemNumber;
+  const techRec = event.body && event.body.techRecord;
+  const msUserDetails = event.body && event.body.msUserDetails ? event.body.msUserDetails : null;
+
+  if (!techRec || !techRec.length) {
+    return Promise.resolve(new HTTPResponse(400, formatErrorMessage(ERRORS.MISSING_PAYLOAD)));
+  }
+  if (!msUserDetails || !msUserDetails.msUser || !msUserDetails.msOid) {
+    return Promise.resolve(new HTTPResponse(400, formatErrorMessage(ERRORS.MISSING_USER)));
+  }
+
+  const techRecord: ITechRecordWrapper = {
+    vin: "",
+    systemNumber,
+    techRecord: techRec
+  };
+
+  return techRecordsService.archiveTechRecordStatus(systemNumber, techRecord, msUserDetails)
+    .then((updatedTechRec: any) => {
+      return new HTTPResponse(200, updatedTechRec);
+    })
+    .catch((error: any) => {
+      console.log(error);
+      return new HTTPResponse(error.statusCode, error.body);
+    });
+}

--- a/src/functions/updateTechRecords.ts
+++ b/src/functions/updateTechRecords.ts
@@ -3,6 +3,7 @@ import TechRecordsService from "../services/TechRecordsService";
 import HTTPResponse from "../models/HTTPResponse";
 import ITechRecordWrapper from "../../@Types/ITechRecordWrapper";
 import {formatErrorMessage} from "../utils/formatErrorMessage";
+import {ERRORS, STATUS} from "../assets/Enums";
 
 const updateTechRecords = (event: any) => {
   const techRecordsDAO = new TechRecordsDAO();
@@ -21,8 +22,11 @@ const updateTechRecords = (event: any) => {
   }
 
   if (!msUserDetails || !msUserDetails.msUser || !msUserDetails.msOid) {
-    return Promise.resolve(new HTTPResponse(400, formatErrorMessage("Microsoft user details not provided")));
+    return Promise.resolve(new HTTPResponse(400, formatErrorMessage(ERRORS.MISSING_USER)));
   }
+
+  const oldStatusCodeString = event.queryStringParameters && event.queryStringParameters.oldStatusCode;
+  const oldStatusCode = oldStatusCodeString ? STATUS[oldStatusCodeString.toUpperCase() as keyof typeof STATUS] : undefined;
 
   const techRecord: ITechRecordWrapper = {
     vin: event.body.vin,
@@ -32,7 +36,7 @@ const updateTechRecords = (event: any) => {
     trailerId: event.body.trailerId,
     techRecord: techRec
   };
-  return techRecordsService.updateTechRecord(techRecord, msUserDetails)
+  return techRecordsService.updateTechRecord(techRecord, msUserDetails, oldStatusCode)
     .then((updatedTechRec: any) => {
       return new HTTPResponse(200, updatedTechRec);
     })

--- a/src/services/TechRecordsService.ts
+++ b/src/services/TechRecordsService.ts
@@ -11,7 +11,6 @@ import {
   VEHICLE_TYPE,
   EU_VEHICLE_CATEGORY
 } from "../assets/Enums";
-import * as _ from "lodash";
 import {
   validatePayload,
   validatePrimaryVrm,
@@ -24,6 +23,10 @@ import {DocumentClient} from "aws-sdk/lib/dynamodb/document_client";
 import QueryOutput = DocumentClient.QueryOutput;
 import {ValidationError, ValidationResult} from "@hapi/joi";
 import {formatErrorMessage} from "../utils/formatErrorMessage";
+import IMsUserDetails from "../../@Types/IUserDetails";
+import {PromiseResult} from "aws-sdk/lib/request";
+import {AWSError} from "aws-sdk/lib/error";
+import {cloneDeep, mergeWith, isArray, isEqual, differenceWith} from "lodash";
 
 /**
  * Fetches the entire list of Technical Records from the database.
@@ -75,7 +78,7 @@ class TechRecordsService {
   }
 
   private filterTechRecordsForIndividualVehicleByStatus(techRecordItem: ITechRecordWrapper, status: string): ITechRecordWrapper {
-    const originalTechRecordItem = _.cloneDeep(techRecordItem);
+    const originalTechRecordItem = cloneDeep(techRecordItem);
     let provisionalOverCurrent = false;
     if (status === STATUS.PROVISIONAL_OVER_CURRENT) {
       provisionalOverCurrent = true;
@@ -235,8 +238,12 @@ class TechRecordsService {
     techRecord.statusCode = STATUS.PROVISIONAL;
   }
 
-  public updateTechRecord(techRecord: ITechRecordWrapper, msUserDetails: any) {
-    return this.createAndArchiveTechRecord(techRecord, msUserDetails)
+  public updateTechRecord(techRecord: ITechRecordWrapper, msUserDetails: IMsUserDetails, oldStatusCode?: STATUS) {
+    return this.manageUpdateLogic(techRecord, msUserDetails, oldStatusCode);
+  }
+
+  private manageUpdateLogic(updatedTechRecord: ITechRecordWrapper, msUserDetails: IMsUserDetails, oldStatusCode: STATUS | undefined) {
+    return this.createAndArchiveTechRecord(updatedTechRecord, msUserDetails, oldStatusCode)
       .then((data: ITechRecordWrapper) => {
         return this.techRecordsDAO.updateSingle(data)
           .then((updatedData: any) => {
@@ -249,36 +256,6 @@ class TechRecordsService {
       .catch((error: any) => {
         throw new HTTPError(error.statusCode, error.body);
       });
-  }
-
-  private async createAndArchiveTechRecord(techRecord: ITechRecordWrapper, msUserDetails: any) {
-    const {statusCode} = techRecord.techRecord[0];
-    delete techRecord.techRecord[0].statusCode;
-    if (statusCode === STATUS.ARCHIVED) {
-      return Promise.reject({statusCode: 400, body: formatErrorMessage(ERRORS.CANNOT_UPDATE_ARCHIVED_RECORD)});
-    }
-    const isPayloadValid = validatePayload(techRecord.techRecord[0], false);
-    this.checkValidationErrors(isPayloadValid);
-    techRecord.techRecord[0] = isPayloadValid.value;
-    try {
-      const data: ITechRecordWrapper[] = await this.getTechRecordsList(techRecord.systemNumber, STATUS.ALL, SEARCHCRITERIA.SYSTEM_NUMBER);
-      if (data.length !== 1) {
-        // systemNumber search should return a unique record
-        return Promise.reject({statusCode: 500, body: ERRORS.NO_UNIQUE_RECORD});
-      }
-      const uniqueRecord = data[0];
-      await this.updateAttributesOutsideTechRecordsArray(uniqueRecord, techRecord);
-      const oldTechRec = this.getTechRecordToArchive(uniqueRecord, statusCode);
-      const newRecord: ITechRecord = _.cloneDeep(oldTechRec);
-      oldTechRec.statusCode = STATUS.ARCHIVED;
-      _.mergeWith(newRecord, techRecord.techRecord[0], this.arrayCustomizer);
-      this.setAuditDetails(newRecord, oldTechRec, msUserDetails);
-      populateFields(newRecord);
-      uniqueRecord.techRecord.push(newRecord);
-      return uniqueRecord;
-    } catch (error) {
-      return Promise.reject({statusCode: error.statusCode, body: error.body});
-    }
   }
 
   public async updateAttributesOutsideTechRecordsArray(uniqueRecord: any, techRecord: ITechRecordWrapper) {
@@ -304,7 +281,10 @@ class TechRecordsService {
       }
       const primaryVrmRecords: QueryOutput = await this.techRecordsDAO.getBySearchTerm(techRecord.primaryVrm, SEARCHCRITERIA.VRM);
       if (primaryVrmRecords.Count! > 0) {
-        return Promise.reject({statusCode: 400, body: formatErrorMessage(`Primary VRM ${techRecord.primaryVrm} already exists`)});
+        return Promise.reject({
+          statusCode: 400,
+          body: formatErrorMessage(`Primary VRM ${techRecord.primaryVrm} already exists`)
+        });
       }
       const previousVrm = uniqueRecord.primaryVrm;
       if (previousVrm) {
@@ -320,7 +300,10 @@ class TechRecordsService {
       }
       const trailerIdRecords: QueryOutput = await this.techRecordsDAO.getBySearchTerm(techRecord.trailerId, SEARCHCRITERIA.TRAILERID);
       if (trailerIdRecords.Count! > 0) {
-        return Promise.reject({statusCode: 400, body: formatErrorMessage(`TrailerId ${techRecord.trailerId} already exists`)});
+        return Promise.reject({
+          statusCode: 400,
+          body: formatErrorMessage(`TrailerId ${techRecord.trailerId} already exists`)
+        });
       }
       const previousTrailerId = uniqueRecord.trailerId;
       uniqueRecord.trailerId = techRecord.trailerId;
@@ -328,8 +311,56 @@ class TechRecordsService {
     }
   }
 
+  public async createAndArchiveTechRecord(updatedTechRecord: ITechRecordWrapper, msUserDetails: IMsUserDetails, oldStatusCode: STATUS | undefined) {
+    const {statusCode} = updatedTechRecord.techRecord[0];
+
+    if ((oldStatusCode && oldStatusCode === STATUS.ARCHIVED) || statusCode === STATUS.ARCHIVED) {
+      return Promise.reject({statusCode: 400, body: formatErrorMessage(ERRORS.CANNOT_USE_UPDATE_TO_ARCHIVE)});
+    }
+    if (oldStatusCode && oldStatusCode === STATUS.CURRENT && statusCode === STATUS.PROVISIONAL) {
+      return Promise.reject({statusCode: 400, body: formatErrorMessage(ERRORS.CANNOT_CHANGE_CURRENT_TO_PROVISIONAL)});
+    }
+    const isPayloadValid = validatePayload(updatedTechRecord.techRecord[0]);
+    this.checkValidationErrors(isPayloadValid);
+
+    updatedTechRecord.techRecord[0] = isPayloadValid.value;
+    return this.getTechRecordsList(updatedTechRecord.systemNumber, STATUS.ALL, SEARCHCRITERIA.SYSTEM_NUMBER)
+      .then(async (data: ITechRecordWrapper[]) => {
+        if (data.length !== 1) {
+          // systemNumber search should return a unique record
+          throw new HTTPError(500, ERRORS.NO_UNIQUE_RECORD);
+        }
+        const techRecordWithAllStatues = data[0];
+        const statusCodeToSearch: string = oldStatusCode ? oldStatusCode : statusCode;
+        await this.updateAttributesOutsideTechRecordsArray(techRecordWithAllStatues, updatedTechRecord);
+        const techRecToArchive = this.getTechRecordToArchive(techRecordWithAllStatues, statusCodeToSearch);
+        const currentTechRec = techRecordWithAllStatues.techRecord.find((techRec) => techRec.statusCode === STATUS.CURRENT);
+        // check if vehicle already has a current and the provisional has been updated to current the mark old current as archived
+        if (currentTechRec && oldStatusCode && oldStatusCode === STATUS.PROVISIONAL && statusCode === STATUS.CURRENT) {
+          currentTechRec.statusCode = STATUS.ARCHIVED;
+          const date = new Date().toISOString();
+          currentTechRec.lastUpdatedAt = date;
+          currentTechRec.lastUpdatedByName = msUserDetails.msUser;
+          currentTechRec.lastUpdatedById = msUserDetails.msOid;
+        }
+        const newRecord: ITechRecord = cloneDeep(techRecToArchive);
+        mergeWith(newRecord, updatedTechRecord.techRecord[0], this.arrayCustomizer);
+        if (oldStatusCode) {
+          newRecord.statusCode = statusCode;
+        }
+        this.setAuditDetails(newRecord, techRecToArchive, msUserDetails);
+        techRecToArchive.statusCode = STATUS.ARCHIVED;
+        populateFields(newRecord);
+        techRecordWithAllStatues.techRecord.push(newRecord);
+        return techRecordWithAllStatues;
+      })
+      .catch((error: any) => {
+        throw new HTTPError(error.statusCode, error.body);
+      });
+  }
+
   private arrayCustomizer(objValue: any, srcValue: any) {
-    if (_.isArray(objValue) && _.isArray(srcValue)) {
+    if (isArray(objValue) && isArray(srcValue)) {
       return srcValue;
     }
   }
@@ -345,7 +376,7 @@ class TechRecordsService {
     }
   }
 
-  private setAuditDetails(newTechRecord: ITechRecord, oldTechRecord: ITechRecord, msUserDetails: any) {
+  private setAuditDetails(newTechRecord: ITechRecord, oldTechRecord: ITechRecord, msUserDetails: IMsUserDetails) {
     const date = new Date().toISOString();
     newTechRecord.createdAt = date;
     newTechRecord.createdByName = msUserDetails.msUser;
@@ -360,7 +391,7 @@ class TechRecordsService {
 
     let updateType = UPDATE_TYPE.TECH_RECORD_UPDATE;
     if (newTechRecord.adrDetails || oldTechRecord.adrDetails) {
-      updateType = _.isEqual(newTechRecord.adrDetails, oldTechRecord.adrDetails) ? UPDATE_TYPE.TECH_RECORD_UPDATE : UPDATE_TYPE.ADR;
+      updateType = isEqual(newTechRecord.adrDetails, oldTechRecord.adrDetails) ? UPDATE_TYPE.TECH_RECORD_UPDATE : UPDATE_TYPE.ADR;
     }
     oldTechRecord.updateType = updateType;
   }
@@ -398,7 +429,7 @@ class TechRecordsService {
       throw new HTTPError(500, ERRORS.NO_UNIQUE_RECORD);
     }
     const uniqueRecord = techRecordWrapper[0];
-    const provisionalTechRecords = uniqueRecord.techRecord.filter((techRecord) => techRecord.statusCode === STATUS.PROVISIONAL);
+    const provisionalTechRecords = this.getTechRecordByStatus(uniqueRecord, STATUS.PROVISIONAL);
     if (provisionalTechRecords.length === 1) {
       provisionalTechRecords[0].statusCode = STATUS.ARCHIVED;
       uniqueRecord.techRecord.push({...uniqueRecord.techRecord[0], statusCode: newStatus});
@@ -414,6 +445,35 @@ class TechRecordsService {
     }
   }
 
+  public async archiveTechRecordStatus(systemNumber: string, techRecordToUpdate: ITechRecordWrapper, userDetails: IMsUserDetails) {
+    const allTechRecordWrapper: ITechRecordWrapper[] = await this.getTechRecordsList(systemNumber, STATUS.ALL, SEARCHCRITERIA.SYSTEM_NUMBER);
+    if (allTechRecordWrapper.length !== 1) {
+      // systemNumber search should return a single record
+      throw new HTTPError(400, formatErrorMessage(ERRORS.NO_UNIQUE_RECORD));
+    }
+    const techRecordWithAllStatues = allTechRecordWrapper[0];
+    const techRecordToArchive = this.getTechRecordToArchive(techRecordWithAllStatues, techRecordToUpdate.techRecord[0].statusCode);
+    if (techRecordToArchive.statusCode === STATUS.ARCHIVED) {
+      throw new HTTPError(400, formatErrorMessage(ERRORS.CANNOT_UPDATE_ARCHIVED_RECORD));
+    }
+    if (!isEqual(techRecordToArchive, techRecordToUpdate.techRecord[0])) {
+      throw new HTTPError(400, formatErrorMessage(ERRORS.CANNOT_ARCHIVE_CHANGED_RECORD));
+    }
+    techRecordToArchive.statusCode = STATUS.ARCHIVED;
+    techRecordToArchive.lastUpdatedAt = new Date().toISOString();
+    techRecordToArchive.lastUpdatedByName = userDetails.msUser;
+    techRecordToArchive.lastUpdatedById = userDetails.msOid;
+    techRecordToArchive.updateType = UPDATE_TYPE.TECH_RECORD_UPDATE;
+
+    let updatedTechRecord;
+    try {
+      updatedTechRecord = await this.techRecordsDAO.updateSingle(techRecordWithAllStatues);
+    } catch (error) {
+      throw new HTTPError(error.statusCode, error.message);
+    }
+    return this.formatTechRecordItemForResponse(updatedTechRecord.Attributes as ITechRecordWrapper);
+  }
+
   public static isStatusUpdateRequired(testStatus: string, testResult: string, testTypeId: string): boolean {
     return testStatus === "submitted" && testResult === "pass" &&
       (this.isTestTypeFirstTest(testTypeId) || this.isTestTypeNotifiableAlteration(testTypeId));
@@ -427,6 +487,10 @@ class TechRecordsService {
   private static isTestTypeNotifiableAlteration(testTypeId: string): boolean {
     const notifiableAlterationIds = ["47", "48"];
     return notifiableAlterationIds.includes(testTypeId);
+  }
+
+  private getTechRecordByStatus(techRecordList: ITechRecordWrapper, statusCode: string) {
+    return techRecordList.techRecord.filter((techRecord) => techRecord.statusCode === statusCode);
   }
 
   public async updateEuVehicleCategory(systemNumber: string, newEuVehicleCategory: EU_VEHICLE_CATEGORY): Promise<HTTPResponse | HTTPError> {
@@ -451,6 +515,55 @@ class TechRecordsService {
       throw new HTTPError(500, HTTPRESPONSE.INTERNAL_SERVER_ERROR);
     }
     return new HTTPResponse(200, this.formatTechRecordItemForResponse(updatedTechRecord.Attributes as ITechRecordWrapper));
+  }
+
+  public addProvisionalTechRecord(techRecord: ITechRecordWrapper, msUserDetails: IMsUserDetails) {
+    return this.addNewProvisionalRecord(techRecord, msUserDetails)
+      .then((data: ITechRecordWrapper) => {
+        return this.techRecordsDAO.updateSingle(data)
+          .then((updatedData: PromiseResult<DocumentClient.UpdateItemOutput, AWSError>) => {
+            return this.formatTechRecordItemForResponse({...updatedData.Attributes} as ITechRecordWrapper);
+          })
+          .catch((error: any) => {
+            throw new HTTPError(error.statusCode, error.message);
+          });
+      })
+      .catch((error: any) => {
+        throw new HTTPError(error.statusCode, error.body);
+      });
+  }
+
+  public addNewProvisionalRecord(techRecordToAdd: ITechRecordWrapper, msUserDetails: IMsUserDetails) {
+    if (techRecordToAdd.techRecord[0].statusCode !== STATUS.PROVISIONAL) {
+      return Promise.reject({statusCode: 400, body: ERRORS.STATUS_CODE_SHOULD_BE_PROVISIONAL});
+    }
+    const isPayloadValid = validatePayload(techRecordToAdd.techRecord[0]);
+    if (isPayloadValid.error) {
+      return Promise.reject({statusCode: 400, body: isPayloadValid.error.details});
+    }
+    return this.getTechRecordsList(techRecordToAdd.systemNumber, STATUS.ALL, SEARCHCRITERIA.SYSTEM_NUMBER)
+      .then((data: ITechRecordWrapper[]) => {
+        if (data.length !== 1) {
+          // systemNumber search should return a unique record
+          throw new HTTPError(500, ERRORS.NO_UNIQUE_RECORD);
+        }
+        const uniqueRecord = data[0];
+        if (this.getTechRecordByStatus(uniqueRecord, STATUS.PROVISIONAL).length > 0) {
+          throw new HTTPError(400, ERRORS.CURRENT_OR_PROVISIONAL_RECORD_FOUND);
+        }
+        techRecordToAdd.techRecord[0].createdAt = new Date().toISOString();
+        techRecordToAdd.techRecord[0].createdByName = msUserDetails.msUser;
+        techRecordToAdd.techRecord[0].createdById = msUserDetails.msOid;
+        delete techRecordToAdd.techRecord[0].lastUpdatedAt;
+        delete techRecordToAdd.techRecord[0].lastUpdatedById;
+        delete techRecordToAdd.techRecord[0].lastUpdatedByName;
+        techRecordToAdd.techRecord[0].updateType = UPDATE_TYPE.TECH_RECORD_UPDATE;
+        uniqueRecord.techRecord.push(techRecordToAdd.techRecord[0]);
+        return uniqueRecord;
+      })
+      .catch((error: any) => {
+        throw new HTTPError(error.statusCode, error.body);
+      });
   }
 }
 

--- a/src/utils/CommonSchema.ts
+++ b/src/utils/CommonSchema.ts
@@ -12,7 +12,8 @@ import {
   VEHICLE_CONFIGURATION,
   VEHICLE_TYPE_VALIDATION,
   RECORD_COMPLETENESS,
-  EU_VEHICLE_CATEGORY_VALIDATION
+  EU_VEHICLE_CATEGORY_VALIDATION,
+  STATUS_CODES
 } from "../assets/Enums";
 
 export const brakesSchema = Joi.object().keys({
@@ -109,5 +110,6 @@ export const commonSchema = Joi.object().keys({
   createdById: Joi.string().optional(),
   lastUpdatedAt: Joi.string().optional().allow(null),
   lastUpdatedByName: Joi.string().optional(),
-  lastUpdatedById: Joi.string().optional()
+  lastUpdatedById: Joi.string().optional(),
+  statusCode: Joi.string().valid(...STATUS_CODES)
 }).required();

--- a/tests/integration/archiveTechRecordStatus.intTest.ts
+++ b/tests/integration/archiveTechRecordStatus.intTest.ts
@@ -1,0 +1,72 @@
+import { emptyDatabase, populateDatabase } from "../util/dbOperations";
+import LambdaTester from "lambda-tester";
+import {
+  HTTPRESPONSE,
+  EU_VEHICLE_CATEGORY,
+  STATUS
+} from "../../src/assets/Enums";
+import { archiveTechRecordStatus } from "../../src/functions/archiveTechRecordStatus";
+import ITechRecordWrapper from "../../@Types/ITechRecordWrapper";
+import mockData from "../resources/technical-records.json";
+import { cloneDeep } from "lodash";
+
+const msUserDetails = {
+  msUser: "dorel",
+  msOid: "1234545"
+};
+
+describe("archiveTechRecordStatus", () => {
+  beforeAll(async () => {
+    jest.restoreAllMocks();
+    // await emptyDatabase();
+    await populateDatabase();
+  });
+  beforeEach(async () => {
+    // await populateDatabase();
+  });
+  afterEach(async () => {
+    // await emptyDatabase();
+  });
+  afterAll(async () => {
+    // await populateDatabase();
+    await emptyDatabase();
+  });
+
+  context(
+    "when trying to update a non archived vehicle tech record status to archived",
+    () => {
+      it("should update the status and set audit details", async () => {
+        const systemNumber: string = "1100047";
+        const techRecord: any = cloneDeep(mockData[43]);
+        const payload = {
+          vin: techRecord.vin,
+          systemNumber: techRecord.systemNumber,
+          primaryVrm: techRecord.primaryVrm,
+          msUserDetails,
+          techRecord: techRecord.techRecord
+        };
+        expect.assertions(2);
+        await LambdaTester(archiveTechRecordStatus)
+          .event({
+            path: `/vehicles/archive/${systemNumber}`,
+            pathParameters: {
+              systemNumber
+            },
+            queryStringParameters: {},
+            body: payload,
+            httpMethod: "PUT",
+            resource: "/vehicles/archive/{systemNumber}"
+          })
+          .expectResolve((result: any) => {
+            expect(result.statusCode).toBe(200);
+            const techRecordWrapper: ITechRecordWrapper = JSON.parse(
+              result.body
+            );
+            expect(techRecordWrapper.techRecord[0].statusCode).toBe(
+              STATUS.ARCHIVED
+            );
+          });
+      });
+    }
+  );
+});

--- a/tests/integration/techRecords.intTest.ts
+++ b/tests/integration/techRecords.intTest.ts
@@ -358,7 +358,7 @@ describe("techRecords", () => {
       });
 
       context("and when trying to update a vehicle", () => {
-        context("and the path parameter systemNumber is valid", () => {
+        context("and the path parameter VIN is valid", () => {
           context("and that vehicle does exist", () => {
             it("should return status 200 and the updated vehicle", async () => {
               // @ts-ignore
@@ -381,13 +381,14 @@ describe("techRecords", () => {
             it("should return error status 404 No resources match the search criteria", async () => {
               // @ts-ignore
               const techRec: ITechRecordWrapper = cloneDeep(mockData[43]);
-              const systemNumber = "NOT A VALID SYSTEM NUMBER";
+              const vin = Date.now().toString();
+              delete techRec.techRecord[0].statusCode;
               const payload = {
                 msUserDetails,
-                systemNumber,
+                systemNumber: "NOT A VALID SYSTEM NUMBER",
                 techRecord: techRec.techRecord
               };
-              const res = await request.put(`vehicles/${systemNumber}`).send(payload);
+              const res = await request.put(`vehicles/${vin}`).send(payload);
               expect(res.status).toEqual(404);
               expect(res.header["access-control-allow-origin"]).toEqual("*");
               expect(res.header["access-control-allow-credentials"]).toEqual("true");
@@ -400,7 +401,7 @@ describe("techRecords", () => {
               // @ts-ignore
               const techRec: ITechRecordWrapper = cloneDeep(mockData[1]);
               techRec.techRecord = [];
-              const res = await request.put(`vehicles/${techRec.systemNumber}`).send(techRec);
+              const res = await request.put(`vehicles/${techRec.vin}`).send(techRec);
               expect(res.status).toEqual(400);
               expect(res.header["access-control-allow-origin"]).toEqual("*");
               expect(res.header["access-control-allow-credentials"]).toEqual("true");

--- a/tests/unit/configuration.unitTest.ts
+++ b/tests/unit/configuration.unitTest.ts
@@ -6,12 +6,14 @@ describe("The configuration service", () => {
         process.env.BRANCH = "local";
         const configService = Configuration.getInstance();
         const functions = configService.getFunctions();
-        expect(functions.length).toEqual(5);
+        expect(functions.length).toEqual(7);
         expect(functions[0].name).toEqual("getTechRecords");
         expect(functions[1].name).toEqual("postTechRecords");
         expect(functions[2].name).toEqual("updateTechRecords");
         expect(functions[3].name).toEqual("updateTechRecordStatus");
         expect(functions[4].name).toEqual("updateEuVehicleCategory");
+        expect(functions[5].name).toEqual("addProvisionalTechRecord");
+        expect(functions[6].name).toEqual("archiveTechRecordStatus");
 
         const DBConfig = configService.getDynamoDBConfig();
         const EndpointsConfig = configService.getEndpoints();
@@ -24,12 +26,14 @@ describe("The configuration service", () => {
         process.env.BRANCH = "local-global";
         const configService = Configuration.getInstance();
         const functions = configService.getFunctions();
-        expect(functions.length).toEqual(5);
+        expect(functions.length).toEqual(7);
         expect(functions[0].name).toEqual("getTechRecords");
         expect(functions[1].name).toEqual("postTechRecords");
         expect(functions[2].name).toEqual("updateTechRecords");
         expect(functions[3].name).toEqual("updateTechRecordStatus");
         expect(functions[4].name).toEqual("updateEuVehicleCategory");
+        expect(functions[5].name).toEqual("addProvisionalTechRecord");
+        expect(functions[6].name).toEqual("archiveTechRecordStatus");
 
         const DBConfig = configService.getDynamoDBConfig();
         expect(DBConfig).toEqual(configService.getConfig().dynamodb["local-global"]);
@@ -39,12 +43,14 @@ describe("The configuration service", () => {
         process.env.BRANCH = "CVSB-XXX";
         const configService = Configuration.getInstance();
         const functions = configService.getFunctions();
-        expect(functions.length).toEqual(5);
+        expect(functions.length).toEqual(7);
         expect(functions[0].name).toEqual("getTechRecords");
         expect(functions[1].name).toEqual("postTechRecords");
         expect(functions[2].name).toEqual("updateTechRecords");
         expect(functions[3].name).toEqual("updateTechRecordStatus");
         expect(functions[4].name).toEqual("updateEuVehicleCategory");
+        expect(functions[5].name).toEqual("addProvisionalTechRecord");
+        expect(functions[6].name).toEqual("archiveTechRecordStatus");
 
         const DBConfig = configService.getDynamoDBConfig();
         const EndpointsConfig = configService.getEndpoints();

--- a/tests/unit/handler.unitTest.ts
+++ b/tests/unit/handler.unitTest.ts
@@ -6,6 +6,8 @@ import TechRecordsService from "../../src/services/TechRecordsService";
 import mockData from "../resources/technical-records.json";
 import {cloneDeep} from "lodash";
 import {Context} from "aws-lambda";
+import ITechRecordWrapper from "../../@Types/ITechRecordWrapper";
+import { STATUS } from "../../src/assets/Enums";
 
 jest.mock("../../src/services/TechRecordsService");
 
@@ -164,6 +166,71 @@ describe("The lambda function handler", () => {
         expect(updateEuVehicleMock.mock.calls[0][1]).toEqual("m1");
       });
 
+      it("should call the /vehicles/add-provisional function with correct event payload", async () => {
+        const payload = {
+          msUserDetails: {
+            msUser: "dorel",
+            msOid: "12314234"
+          },
+          vin: "XMGDE02FS0H012345",
+          systemNumber: mockData[26].systemNumber,
+          techRecord: mockData[26].techRecord
+        };
+
+        const vehicleRecordEvent = {
+          path: "/vehicles/add-provisional/10000027",
+          pathParameters: {
+            systemNumber: "10000027"
+          },
+          resource: "/vehicles/add-provisional/{systemNumber}",
+          httpMethod: "POST",
+          body: JSON.stringify(payload)
+        };
+        const addProvisionalMock = jest.fn().mockImplementation(() => {
+          return Promise.resolve(new HTTPResponse(200, {}));
+        });
+        TechRecordsService.prototype.addProvisionalTechRecord = addProvisionalMock;
+        const result = await handler(vehicleRecordEvent, ctx);
+        expect.assertions(2);
+        expect(result.statusCode).toEqual(200);
+        expect(
+          TechRecordsService.prototype.addProvisionalTechRecord
+        ).toHaveBeenCalled();
+      });
+
+      it("should call the /vehicles/archive function with correct event payload", async () => {
+        const payload = {
+          msUserDetails: {
+            msUser: "dorel",
+            msOid: "12314234"
+          },
+          vin: "XMGDE02FS0H012345",
+          systemNumber: mockData[26].systemNumber,
+          techRecord: mockData[26].techRecord
+        };
+
+        const vehicleRecordEvent = {
+          path: "/vehicles/archive/10000027",
+          pathParameters: {
+            systemNumber: "10000027"
+          },
+          resource: "/vehicles/archive/{systemNumber}",
+          httpMethod: "PUT",
+          body: JSON.stringify(payload)
+        };
+        const archiveTechRecordStatusMock = jest.fn().mockImplementation(() => {
+          return Promise.resolve(new HTTPResponse(200, {}));
+        });
+        TechRecordsService.prototype.archiveTechRecordStatus = archiveTechRecordStatusMock;
+        const result = await handler(vehicleRecordEvent, ctx);
+        console.log("error on handler",result);
+        expect.assertions(2);
+        expect(result.statusCode).toEqual(200);
+        expect(
+          TechRecordsService.prototype.archiveTechRecordStatus
+        ).toHaveBeenCalled();
+      });
+
       it("should return error on empty event", async () => {
         const result = await handler(null, ctx);
 
@@ -211,12 +278,14 @@ describe("The configuration service", () => {
       process.env.BRANCH = "local";
       const configService = Configuration.getInstance();
       const functions = configService.getFunctions();
-      expect(functions.length).toEqual(5);
+      expect(functions.length).toEqual(7);
       expect(functions[0].name).toEqual("getTechRecords");
       expect(functions[1].name).toEqual("postTechRecords");
       expect(functions[2].name).toEqual("updateTechRecords");
       expect(functions[3].name).toEqual("updateTechRecordStatus");
       expect(functions[4].name).toEqual("updateEuVehicleCategory");
+      expect(functions[5].name).toEqual("addProvisionalTechRecord");
+      expect(functions[6].name).toEqual("archiveTechRecordStatus");
 
 
       const DBConfig = configService.getDynamoDBConfig();
@@ -229,12 +298,14 @@ describe("The configuration service", () => {
       process.env.BRANCH = "local-global";
       const configService = Configuration.getInstance();
       const functions = configService.getFunctions();
-      expect(functions.length).toEqual(5);
+      expect(functions.length).toEqual(7);
       expect(functions[0].name).toEqual("getTechRecords");
       expect(functions[1].name).toEqual("postTechRecords");
       expect(functions[2].name).toEqual("updateTechRecords");
       expect(functions[3].name).toEqual("updateTechRecordStatus");
       expect(functions[4].name).toEqual("updateEuVehicleCategory");
+      expect(functions[5].name).toEqual("addProvisionalTechRecord");
+      expect(functions[6].name).toEqual("archiveTechRecordStatus");
 
       const DBConfig = configService.getDynamoDBConfig();
       expect(DBConfig).toEqual(configService.getConfig().dynamodb["local-global"]);
@@ -246,12 +317,14 @@ describe("The configuration service", () => {
       process.env.BRANCH = "CVSB-XXX";
       const configService = Configuration.getInstance();
       const functions = configService.getFunctions();
-      expect(functions.length).toEqual(5);
+      expect(functions.length).toEqual(7);
       expect(functions[0].name).toEqual("getTechRecords");
       expect(functions[1].name).toEqual("postTechRecords");
       expect(functions[2].name).toEqual("updateTechRecords");
       expect(functions[3].name).toEqual("updateTechRecordStatus");
       expect(functions[4].name).toEqual("updateEuVehicleCategory");
+      expect(functions[5].name).toEqual("addProvisionalTechRecord");
+      expect(functions[6].name).toEqual("archiveTechRecordStatus");
 
       const DBConfig = configService.getDynamoDBConfig();
       expect(DBConfig).toEqual(configService.getConfig().dynamodb.remote);


### PR DESCRIPTION
Backend service update to archive a tech-record, to add a new provisional tech-record and to manually change the statusCode on a tech-record

Link to the closed PR (for history): https://github.com/dvsa/cvs-svc-technical-records/pull/121