### PR TITLE
feature/CVSB-10185 - GET/POST/PUT upper case conversion

### DIFF
--- a/src/models/TechRecordsDAO.ts
+++ b/src/models/TechRecordsDAO.ts
@@ -32,6 +32,7 @@ class TechRecordsDAO {
   }
 
   public getBySearchTerm(searchTerm: string, searchCriteria: ISearchCriteria) {
+    searchTerm = searchTerm.toUpperCase();
     const query: QueryInput = {
       TableName: this.tableName,
       IndexName: "",
@@ -100,6 +101,7 @@ class TechRecordsDAO {
   }
 
   public createSingle(techRecord: ITechRecordWrapper) {
+    techRecord = capitaliseGeneralVehicleAttributes(techRecord);
     const query = {
       TableName: this.tableName,
       Item: techRecord,
@@ -114,6 +116,7 @@ class TechRecordsDAO {
 
   public updateSingle(techRecord: ITechRecordWrapper) {
     techRecord.partialVin = populatePartialVin(techRecord.vin);
+    techRecord = capitaliseGeneralVehicleAttributes(techRecord);
     const query = {
       TableName: this.tableName,
       Key: {
@@ -247,6 +250,15 @@ const isTrailerId = (searchTerm: string): boolean => {
   // A letter followed by exactly 6 numbers
   const isLetterAndNumbersTrailerId = TRAILER_REGEX.test(searchTerm);
   return isAllNumbersTrailerId || isLetterAndNumbersTrailerId;
+};
+
+export const capitaliseGeneralVehicleAttributes = (techRecord: ITechRecordWrapper) => {
+  techRecord.vin = techRecord.vin?.toUpperCase();
+  techRecord.partialVin = techRecord.partialVin?.toUpperCase();
+  techRecord.primaryVrm = techRecord.primaryVrm?.toUpperCase();
+  techRecord.trailerId = techRecord.trailerId?.toUpperCase();
+  techRecord.secondaryVrms = techRecord.secondaryVrms?.map((vrm: string) => vrm.toUpperCase());
+  return techRecord;
 };
 
 export {TechRecordsDAO as default, isTrailerSearch, isPartialVinSearch, isTrailerId, isVinSearch, isVrmSearch} ;

--- a/src/utils/validations/AdrValidation.ts
+++ b/src/utils/validations/AdrValidation.ts
@@ -19,7 +19,7 @@ export const adrValidation = Joi.object().keys({
   }).required(),
   permittedDangerousGoods: Joi.array().items(Joi.string()).min(1).required(),
   compatibilityGroupJ: Joi.boolean().optional().allow(null),
-  additionalExaminerNotes: Joi.string().optional().allow(null),
+  additionalExaminerNotes: Joi.string().max(1024).optional().allow(null),
   applicantDetails: Joi.object().keys({
     name: Joi.string().max(150).required(),
     street: Joi.string().max(150).required(),


### PR DESCRIPTION
Update the GET request, on the vehicles (tech records) backend service, to ensure that the search criteria is capitalised before it hits the DynamoDB
POST/PUT -> vin, partialVin, primaryVrm, trailerId, secondaryVrm to upper case

https://jira.dvsacloud.uk/browse/CVSB-10185