### PR TITLE
feat(cb2-396): add long semi trailer to vehicle configuration enum

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -842,6 +842,7 @@ components:
             - four-in-line
             - dolly
             - full drawbar
+            - long semi-trailer
           description: 'Used for all vehicle types - PSV, HGV and TRL'
         brakes:
           $ref: '#/components/schemas/brakes'
@@ -959,6 +960,7 @@ components:
             - four-in-line
             - dolly
             - full drawbar
+            - long semi-trailer
           description: 'Used for all vehicle types - PSV, HGV and TRL'
         numberOfWheelsDriven:
           type: number

--- a/docs/tech-records-api.yml
+++ b/docs/tech-records-api.yml
@@ -1080,6 +1080,7 @@ components:
             - four-in-line
             - dolly
             - full drawbar
+            - long semi-trailer
           description: 'Used for all vehicle types - PSV, HGV and TRL'
         brakes:
           $ref: '#/components/schemas/brakes'

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:integration": "BRANCH=local jest --testMatch=\"**/*.intTest.ts\" --runInBand",
     "test-i": "npm run test:integration -- --globalSetup='./scripts/setup.ts' --globalTeardown='./scripts/teardown.ts'",
     "prepush": "npm t && npm run build && npm run test-i",
-    "security-checks": "git secrets --scan && git log -p | scanrepo",
+    "security-checks": "git secrets --scan",
     "lint": "tslint src/**/*.ts tests/**/*.ts",
     "sonar-scanner": "sonar-scanner",
     "audit": "npm audit --prod",

--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -132,7 +132,8 @@ export const VEHICLE_CONFIGURATION: string[] = [
     "drawbar",
     "four-in-line",
     "dolly",
-    "full drawbar"
+    "full drawbar",
+    "long semi-trailer"
 ];
 
 export const EU_VEHICLE_CATEGORY_VALIDATION: string[] = [


### PR DESCRIPTION
## Cater for new Trailer Types (Long Semi Trailers)

Adds 'long semi-trailer' to vehicleConfiguration enum to reflect changes in VT.

Also removing scanrepo

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-396)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
