### PR TITLE
Feature/vta 531

### DIFF
--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -32,7 +32,7 @@ export enum HTTPRESPONSE {
     NO_STATUS_UPDATE_REQUIRED = "No status update required",
     NO_EU_VEHICLE_CATEGORY_UPDATE_REQUIRED = "No EU vehicle category update required",
     INVALID_EU_VEHICLE_CATEGORY = "Invalid EU vehicle category",
-    EU_VEHICLE_CATEGORY_MORE_THAN_ONE_TECH_RECORD = "The vehicle has more than one non archived Tech record.",
+    EU_VEHICLE_CATEGORY_MORE_THAN_TWO_TECH_RECORD = "The vehicle has more than two non archived Tech records.",
     TECHINICAL_RECORD_CREATED = "Technical Record created"
 }
 

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -271,7 +271,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
     const nonArchivedTechRecord = techRecordWrapper.techRecord.filter(
       (techRecord) => techRecord.statusCode !== enums.STATUS.ARCHIVED
     );
-    if (nonArchivedTechRecord.length > 1) {
+    if (nonArchivedTechRecord.length > 2) {
       throw this.Error(
         400,
         enums.HTTPRESPONSE.EU_VEHICLE_CATEGORY_MORE_THAN_ONE_TECH_RECORD

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -274,7 +274,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
     if (nonArchivedTechRecord.length > 2) {
       throw this.Error(
         400,
-        enums.HTTPRESPONSE.EU_VEHICLE_CATEGORY_MORE_THAN_ONE_TECH_RECORD
+        enums.HTTPRESPONSE.EU_VEHICLE_CATEGORY_MORE_THAN_TWO_TECH_RECORD
       );
     }
     if (nonArchivedTechRecord.length === 0) {

--- a/tests/unit/TechRecordsService.unitTest.ts
+++ b/tests/unit/TechRecordsService.unitTest.ts
@@ -869,10 +869,11 @@ describe("updateEuVehicleCategory", () => {
   });
 
   context("when finding more than one non-archived tech-records", () => {
-    it("should throw error More than one non-archived records found", async () => {
+    it("should throw error More than two non-archived records found", async () => {
       const systemNumber = "10000001";
       const record: any = cloneDeep(records[0]);
       const techRecord = record.techRecord[0];
+      record.techRecord.push(techRecord);
       record.techRecord.push(techRecord);
       const MockDAO = jest.fn().mockImplementation(() => {
         return {
@@ -890,7 +891,7 @@ describe("updateEuVehicleCategory", () => {
       } catch (error) {
         expect(error.statusCode).toEqual(400);
         // FIXME: from array to string
-        expect(error.body.errors).toContain(HTTPRESPONSE.EU_VEHICLE_CATEGORY_MORE_THAN_ONE_TECH_RECORD);
+        expect(error.body.errors).toContain(HTTPRESPONSE.EU_VEHICLE_CATEGORY_MORE_THAN_TWO_TECH_RECORD);
       }
     });
   });


### PR DESCRIPTION
## BE :  Premature Error Throwing Logic

The back-end service should allow for a current and provisional to be returned (2 records) as per CVS.
[link to ticket number](https://dvsa.atlassian.net/browse/VTA-531)

## Checklist

- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
