### PR TITLE
data(cb2-4887): adds vtm test data for psv validation groups

### DIFF
--- a/tests/resources/technical-records.json
+++ b/tests/resources/technical-records.json
@@ -28246,5 +28246,6338 @@
         "vehicleType": "psv"
       }
     ]
+  },
+  {
+    "vtmComment": "Annual Test, Test Type ID = 1, Vehicle = PSV",
+    "systemNumber": "3901068",
+    "vin": "TS9EB03GS7P130072",
+    "partialVin": "130072",
+    "primaryVrm": "W200WCM",
+    "secondaryVrms": ["609832Z"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 126,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 642,
+              "tyreSize": "215/75-17.5"
+            },
+            "weights": {
+              "designWeight": 3900,
+              "gbWeight": 3900,
+              "kerbWeight": 2440,
+              "ladenWeight": 3745
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 124,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 642,
+              "tyreSize": "215/75-17.5"
+            },
+            "weights": {
+              "designWeight": 6550,
+              "gbWeight": 6550,
+              "kerbWeight": 3660,
+              "ladenWeight": 5218
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON LTD",
+        "bodyModel": "PRIMO",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "090202",
+        "brakes": {
+          "brakeCode": "090202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 1434,
+            "secondaryBrakeForceA": 2017,
+            "serviceBrakeForceA": 4033
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 976,
+            "secondaryBrakeForceB": 1525,
+            "serviceBrakeForceB": 3050
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "ENTERPRISE BUS LTD",
+        "chassisModel": "PLASMA",
+        "coifCertifierName": "JOHN DOE T/S 41",
+        "coifDate": "2008-04-24",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2015-06-09T14:34:47.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 9000,
+        "grossGbWeight": 9000,
+        "grossKerbWeight": 6100,
+        "grossLadenWeight": 8963,
+        "lastUpdatedAt": "2022-03-16T17:04:15.499Z",
+        "lastUpdatedById": "70302477",
+        "lastUpdatedByName": "Doe, Jane",
+        "manufactureYear": 2008,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "08050",
+          "microfilmSerialNumber": "0098"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "BUSDIR",
+        "recordCompleteness": "complete",
+        "regnDate": "2008-05-01",
+        "remarks": "21 SEAT BELTS FITTED. BUILT TO BUS DIRECTIVE 2001/85 CLASS I, ACCESSIBILITY TO ANNEX VII, REG 5. FRONT AXLE TYRE BONUS LOAD OF 15%. 28 & 13, 27 & 14 OR 25 SEATS & 1 WHEELCHAIR WITH 12 STANDEES.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 28,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 13,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 126,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 642,
+              "tyreSize": "215/75-17.5"
+            },
+            "weights": {
+              "designWeight": 3900,
+              "gbWeight": 3900,
+              "kerbWeight": 2440,
+              "ladenWeight": 3745
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 124,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 642,
+              "tyreSize": "215/75-17.5"
+            },
+            "weights": {
+              "designWeight": 6550,
+              "gbWeight": 6550,
+              "kerbWeight": 3660,
+              "ladenWeight": 5218
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON LTD",
+        "bodyModel": "PRIMO",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "090202",
+        "brakes": {
+          "brakeCode": "090202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 1434,
+            "secondaryBrakeForceA": 2017,
+            "serviceBrakeForceA": 4033
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 976,
+            "secondaryBrakeForceB": 1525,
+            "serviceBrakeForceB": 3050
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "ENTERPRISE BUS LTD",
+        "chassisModel": "PLASMA",
+        "coifCertifierName": "JOHN DOE T/S 41",
+        "coifDate": "2008-04-24",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-16T17:04:15.499Z",
+        "createdById": "70302477",
+        "createdByName": "Doe, Jane",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m2",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 9000,
+        "grossGbWeight": 9000,
+        "grossKerbWeight": 6100,
+        "grossLadenWeight": 8963,
+        "manufactureYear": 2008,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "08050",
+          "microfilmSerialNumber": "0098"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "BUSDIR",
+        "recordCompleteness": "complete",
+        "regnDate": "2008-05-01",
+        "remarks": "21 SEAT BELTS FITTED. BUILT TO BUS DIRECTIVE 2001/85 CLASS I, ACCESSIBILITY TO ANNEX VII, REG 5. FRONT AXLE TYRE BONUS LOAD OF 15%. 28 & 13, 27 & 14 OR 25 SEATS & 1 WHEELCHAIR WITH 12 STANDEES.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 28,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 13,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Class 6A seatbelt installation check (annual test), Test Type ID = 3, Vehicle = PSV",
+    "systemNumber": "4233111",
+    "vin": "SZAN4X20001867036",
+    "partialVin": "867036",
+    "primaryVrm": "YR10AZA",
+    "secondaryVrms": ["675590Z"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 7100,
+              "gbWeight": 6300,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "SCANIA/OMNI",
+        "bodyModel": "OMNICITY",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "163202",
+        "brakes": {
+          "brakeCode": "163202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2611,
+            "secondaryBrakeForceA": 3672,
+            "serviceBrakeForceA": 7344
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1862,
+            "secondaryBrakeForceB": 2910,
+            "serviceBrakeForceB": 5820
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "exhaust"
+        },
+        "chassisMake": "SCANIA",
+        "chassisModel": "N230UB4X2EB",
+        "coifCertifierName": "JOHN DOE T/S 46",
+        "coifDate": "2010-01-19",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2020-11-19T18:26:16.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 19100,
+        "grossGbWeight": 17800,
+        "grossKerbWeight": 11640,
+        "grossLadenWeight": 16320,
+        "lastUpdatedAt": "2022-03-11T12:43:28.843Z",
+        "lastUpdatedById": "70301545",
+        "lastUpdatedByName": "Charles, Daniel",
+        "manufactureYear": 2010,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "10019",
+          "microfilmSerialNumber": "0187"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "complete",
+        "regnDate": "2010-03-01",
+        "remarks": "STEP HEIGHT 350/220MM IN KNEEL. 39 & 32, 42 & 27 OR 39 SEATS & 1 WHEELCHAIR WITH 27 STANDEES. MANUAL RAMP WITH THROTTLE INTERLOCK & WARNING LIGHT WHEN DEPLOYED. DDA SCHEDULES 1 & 2.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 39,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": true,
+        "speedRestriction": 59,
+        "standingCapacity": 32,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 7100,
+              "gbWeight": 6300,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "SCANIA/OMNI",
+        "bodyModel": "OMNICITY",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "163202",
+        "brakes": {
+          "brakeCode": "163202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2611,
+            "secondaryBrakeForceA": 3672,
+            "serviceBrakeForceA": 7344
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1862,
+            "secondaryBrakeForceB": 2910,
+            "serviceBrakeForceB": 5820
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "exhaust"
+        },
+        "chassisMake": "SCANIA",
+        "chassisModel": "N230UB4X2EB",
+        "coifCertifierName": "JOHN DONHUE T/S 46",
+        "coifDate": "2010-01-19",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-11T12:43:28.843Z",
+        "createdById": "70301545",
+        "createdByName": "Doe, Johnathan",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m3",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 19100,
+        "grossGbWeight": 17800,
+        "grossKerbWeight": 11640,
+        "grossLadenWeight": 16320,
+        "manufactureYear": 2010,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "10019",
+          "microfilmSerialNumber": "0187"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "complete",
+        "regnDate": "2010-03-01",
+        "remarks": "STEP HEIGHT 350/220MM IN KNEEL. 39 & 32, 42 & 27 OR 39 SEATS & 1 WHEELCHAIR WITH 27 STANDEES. MANUAL RAMP WITH THROTTLE INTERLOCK & WARNING LIGHT WHEN DEPLOYED. DDA SCHEDULES 1 & 2.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 39,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": true,
+        "speedRestriction": 59,
+        "standingCapacity": 32,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Class 6A seatbelt installation check (first test), Test Type ID = 4, Vehicle = PSV",
+    "systemNumber": "4915072",
+    "vin": "LC06S24R5D0000029",
+    "partialVin": "000029",
+    "primaryVrm": "LC63CYA",
+    "secondaryVrms": [" "],
+    "techRecord": [
+      {
+        "approvalTypeNumber": "e09*2007/0046*0567",
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 152,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "e",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 7100,
+              "gbWeight": 6550,
+              "kerbWeight": 4715,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "e",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11450,
+              "kerbWeight": 9160,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "BYD",
+        "bodyModel": "BYD EBUS GREENCITY (",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "brakeCode": "178202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2842,
+            "secondaryBrakeForceA": 3997,
+            "serviceBrakeForceA": 7994
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 2208,
+            "secondaryBrakeForceB": 3450,
+            "serviceBrakeForceB": 6900
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "none",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "BYD",
+        "chassisModel": "K9",
+        "coifCertifierName": "JON DOE T/S 15",
+        "coifDate": "2013-10-08",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2017-10-09T10:24:56.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 19100,
+        "grossGbWeight": 18000,
+        "grossKerbWeight": 13800,
+        "grossLadenWeight": 17765,
+        "lastUpdatedAt": "2021-11-11T18:47:50.000000Z",
+        "manufactureYear": 2013,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "14099",
+          "microfilmSerialNumber": "0588"
+        },
+        "modelLiteral": "BYD EBUS GREENCITY (CE)",
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "ECWVTA",
+        "recordCompleteness": "complete",
+        "regnDate": "2013-11-11",
+        "remarks": "EC WHOLE VEHICLE TYPE APPROVAL. 21 SEATED & 39 STANDING OR 21 SEATED, 1 W/CHAIR & 34 STANDING. LIGHT ALLOY RIMS. A/C SYSTEM ON ROOF. POWER OPERATED RAMP. PREHEATER.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 21,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 39,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": "K9E",
+        "variantVersionNumber": "...",
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": "e09*2007/0046*0567",
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 152,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "e",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 7100,
+              "gbWeight": 6550,
+              "kerbWeight": 4715,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "e",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11450,
+              "kerbWeight": 9160,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "BYD",
+        "bodyModel": "BYD EBUS GREENCITY (",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "brakeCode": "178202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2842,
+            "secondaryBrakeForceA": 3997,
+            "serviceBrakeForceA": 7994
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 2208,
+            "secondaryBrakeForceB": 3450,
+            "serviceBrakeForceB": 6900
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "none",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "BYD",
+        "chassisModel": "K9",
+        "coifCertifierName": "JON DOE T/S 15",
+        "coifDate": "2013-10-08",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2017-10-09T10:24:56.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 19100,
+        "grossGbWeight": 18000,
+        "grossKerbWeight": 13800,
+        "grossLadenWeight": 17765,
+        "lastUpdatedAt": "2021-11-11T18:47:50.000000Z",
+        "manufactureYear": 2013,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "14099",
+          "microfilmSerialNumber": "0588"
+        },
+        "modelLiteral": "BYD EBUS GREENCITY (CE)",
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "2013-11-11",
+        "remarks": "EC WHOLE VEHICLE TYPE APPROVAL. 21 SEATED & 39 STANDING OR 21 SEATED, 1 W/CHAIR & 34 STANDING. LIGHT ALLOY RIMS. A/C SYSTEM ON ROOF. POWER OPERATED RAMP. PREHEATER. SCHEDULE REG 5. VEHICLE ALREADY HAS APPROVAL TO ANNEX 8 OF REG 107. VEHICLE ONLY INSPECTED FOR DESTINATION GEAR AND REPOSTING OF THE PRIORITY SEATS (4) AND ANY IMEDIATELY EFFECTED ITEMS.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 21,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 39,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": "K9E",
+        "variantVersionNumber": "...",
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": "e09*2007/0046*0567",
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 152,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "e",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 7100,
+              "gbWeight": 6550,
+              "kerbWeight": 4715,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "e",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11450,
+              "kerbWeight": 9160,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "BYD",
+        "bodyModel": "BYD EBUS GREENCITY (",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "brakeCode": "178202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2842,
+            "secondaryBrakeForceA": 3997,
+            "serviceBrakeForceA": 7994
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 2208,
+            "secondaryBrakeForceB": 3450,
+            "serviceBrakeForceB": 6900
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "none",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "BYD",
+        "chassisModel": "K9",
+        "coifCertifierName": "JON DOE T/S 15",
+        "coifDate": "2013-10-08",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2017-10-09T10:24:56.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 19100,
+        "grossGbWeight": 18000,
+        "grossKerbWeight": 13800,
+        "grossLadenWeight": 17765,
+        "lastUpdatedAt": "2022-03-11T12:45:44.724Z",
+        "lastUpdatedById": "70301545",
+        "lastUpdatedByName": "Charles, Daniel",
+        "manufactureYear": 2013,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "14099",
+          "microfilmSerialNumber": "0588"
+        },
+        "modelLiteral": "BYD EBUS GREENCITY (CE)",
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "2013-11-11",
+        "remarks": "EC WHOLE VEHICLE TYPE APPROVAL. 21 SEATED & 39 STANDING OR 21 SEATED, 1 W/CHAIR & 34 STANDING. LIGHT ALLOY RIMS. A/C SYSTEM ON ROOF. POWER OPERATED RAMP. PREHEATER. SCHEDULE REG 5. VEHICLE ALREADY HAS APPROVAL TO ANNEX 8 OF REG 107. VEHICLE ONLY INSPECTED FOR DESTINATION GEAR AND REPOSTING OF THE PRIORITY SEATS (4) AND ANY IMEDIATELY EFFECTED ITEMS. VEHICLES CHECKED FOR COMPLIANCE WITH ANNEX 8 OF REG 107 FOR PRIORITY SEATS POSITION ALTERED. NO CHANGE IN SEATING CAPACITY ON WEIGHTS.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 21,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 39,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": "K9E",
+        "variantVersionNumber": "...",
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": "e09*2007/0046*0567",
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 152,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "e",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 7100,
+              "gbWeight": 6550,
+              "kerbWeight": 4715,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "e",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11450,
+              "kerbWeight": 9160,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "BYD",
+        "bodyModel": "BYD EBUS GREENCITY (",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "brakeCode": "178202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2842,
+            "secondaryBrakeForceA": 3997,
+            "serviceBrakeForceA": 7994
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 2208,
+            "secondaryBrakeForceB": 3450,
+            "serviceBrakeForceB": 6900
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "none",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "BYD",
+        "chassisModel": "K9",
+        "coifCertifierName": "JON DOE T/S 15",
+        "coifDate": "2013-10-08",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-11T12:45:44.724Z",
+        "createdById": "70301545",
+        "createdByName": "Doe, Johnathan",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m3",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 19100,
+        "grossGbWeight": 18000,
+        "grossKerbWeight": 13800,
+        "grossLadenWeight": 17765,
+        "manufactureYear": 2013,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "14099",
+          "microfilmSerialNumber": "0588"
+        },
+        "modelLiteral": "BYD EBUS GREENCITY (CE)",
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "2013-11-11",
+        "remarks": "EC WHOLE VEHICLE TYPE APPROVAL. 21 SEATED & 39 STANDING OR 21 SEATED, 1 W/CHAIR & 34 STANDING. LIGHT ALLOY RIMS. A/C SYSTEM ON ROOF. POWER OPERATED RAMP. PREHEATER. SCHEDULE REG 5. VEHICLE ALREADY HAS APPROVAL TO ANNEX 8 OF REG 107. VEHICLE ONLY INSPECTED FOR DESTINATION GEAR AND REPOSTING OF THE PRIORITY SEATS (4) AND ANY IMEDIATELY EFFECTED ITEMS. VEHICLES CHECKED FOR COMPLIANCE WITH ANNEX 8 OF REG 107 FOR PRIORITY SEATS POSITION ALTERED. NO CHANGE IN SEATING CAPACITY ON WEIGHTS.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 21,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 39,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": "K9E",
+        "variantVersionNumber": "...",
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Paid annual test retest, Test Type ID = 7, Vehicle = PSV",
+    "systemNumber": "2174458",
+    "vin": "WDB6703742N083329",
+    "partialVin": "083329",
+    "primaryVrm": "V78DBB",
+    "secondaryVrms": ["J10CTL"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 124,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 758,
+              "tyreSize": "205/75-17.5"
+            },
+            "weights": {
+              "designWeight": 2800,
+              "gbWeight": 2800,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 122,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 758,
+              "tyreSize": "205/75-17.5"
+            },
+            "weights": {
+              "designWeight": 5600,
+              "gbWeight": 5600,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "AUTOBUS CLASSIQUE",
+        "bodyModel": "NOUVELLE/VARIO2",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "076222",
+        "brakes": {
+          "brakeCode": "076222",
+          "brakeCodeOriginal": "222",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 1210,
+            "secondaryBrakeForceA": 1701,
+            "serviceBrakeForceA": 3402
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 802,
+            "secondaryBrakeForceB": 1252,
+            "serviceBrakeForceB": 2505
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle Secondary brake on axle 2",
+          "retarderBrakeOne": "exhaust",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "MERCEDES",
+        "chassisModel": "814D",
+        "coifCertifierName": "JOHN DOE",
+        "coifDate": "1999-06-25",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2020-09-18T11:13:42.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 7490,
+        "grossGbWeight": 7490,
+        "grossKerbWeight": 5010,
+        "grossLadenWeight": 7560,
+        "lastUpdatedAt": "2022-03-15T17:43:42.070Z",
+        "lastUpdatedById": "70302477",
+        "lastUpdatedByName": "Evans, Richard",
+        "manufactureYear": 1999,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "99112",
+          "microfilmSerialNumber": "0476"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "1999-09-01",
+        "remarks": "33 SEAT BELTS FITTED\\nLUGGAGE REAR BOOT ONLY 340KG",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 33,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 0,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 124,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 758,
+              "tyreSize": "205/75-17.5"
+            },
+            "weights": {
+              "designWeight": 2800,
+              "gbWeight": 2800,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 122,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 758,
+              "tyreSize": "205/75-17.5"
+            },
+            "weights": {
+              "designWeight": 5600,
+              "gbWeight": 5600,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "AUTOBUS CLASSIQUE",
+        "bodyModel": "NOUVELLE/VARIO2",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "076222",
+        "brakes": {
+          "brakeCode": "076222",
+          "brakeCodeOriginal": "222",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 1210,
+            "secondaryBrakeForceA": 1701,
+            "serviceBrakeForceA": 3402
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 802,
+            "secondaryBrakeForceB": 1252,
+            "serviceBrakeForceB": 2505
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle Secondary brake on axle 2",
+          "retarderBrakeOne": "exhaust",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "MERCEDES",
+        "chassisModel": "814D",
+        "coifCertifierName": "JOHN DOE",
+        "coifDate": "1999-06-25",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-15T17:43:42.070Z",
+        "createdById": "70302477",
+        "createdByName": "Doe, John",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m2",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 7490,
+        "grossGbWeight": 7490,
+        "grossKerbWeight": 5010,
+        "grossLadenWeight": 7560,
+        "manufactureYear": 1999,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "99112",
+          "microfilmSerialNumber": "0476"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "1999-09-01",
+        "remarks": "33 SEAT BELTS FITTED\\nLUGGAGE REAR BOOT ONLY 340KG",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 33,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 0,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Paid retest with Class 6A seatbelt installation check, Test Type ID = 8, Vehicle = PSV",
+    "systemNumber": "2397370",
+    "vin": "YV3S2C611XC000054",
+    "partialVin": "000054",
+    "primaryVrm": "V67MOA",
+    "secondaryVrms": ["221207Z"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6500,
+              "gbWeight": 6300,
+              "kerbWeight": 4050,
+              "ladenWeight": 6525
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 11500,
+              "gbWeight": 11500,
+              "kerbWeight": 7700,
+              "ladenWeight": 11725
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON/TRANSBUS",
+        "bodyModel": "PRESIDENT",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "182202",
+        "brakes": {
+          "brakeCode": "182202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2920,
+            "secondaryBrakeForceA": 4106,
+            "serviceBrakeForceA": 8212
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1876,
+            "secondaryBrakeForceB": 2931,
+            "serviceBrakeForceB": 5862
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE 58",
+        "coifDate": "1999-11-25",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2016-09-07T14:30:16.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18000,
+        "grossGbWeight": 17800,
+        "grossKerbWeight": 11725,
+        "grossLadenWeight": 18250,
+        "lastUpdatedAt": "2021-11-11T18:47:50.000000Z",
+        "manufactureYear": 1999,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "12025",
+          "microfilmSerialNumber": "0451"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "0001-01-01",
+        "remarks": "W/CHAIR RAMP AND DRIVERS AIR CON\\nSEATS 45. 29 OR 27 AND 1 W/CHAIR AND 25 STANDEES",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 29,
+        "seatsUpperDeck": 45,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 25,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6500,
+              "gbWeight": 6300,
+              "kerbWeight": 4050,
+              "ladenWeight": 6525
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 11500,
+              "gbWeight": 11500,
+              "kerbWeight": 7700,
+              "ladenWeight": 11725
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON/TRANSBUS",
+        "bodyModel": "PRESIDENT",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "182202",
+        "brakes": {
+          "brakeCode": "182202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2920,
+            "secondaryBrakeForceA": 4106,
+            "serviceBrakeForceA": 8212
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1876,
+            "secondaryBrakeForceB": 2931,
+            "serviceBrakeForceB": 5862
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE 58",
+        "coifDate": "1999-11-25",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2016-09-07T14:30:16.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18000,
+        "grossGbWeight": 17800,
+        "grossKerbWeight": 11725,
+        "grossLadenWeight": 18250,
+        "lastUpdatedAt": "2021-11-11T18:47:50.000000Z",
+        "manufactureYear": 1999,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "12025",
+          "microfilmSerialNumber": "0451"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "0001-01-01",
+        "remarks": "W/CHAIR RAMP AND DRIVERS AIR CON\\nSEATS 45. 29 OR 27 AND 1 W/CHAIR AND 25 STANDEES\\nDDA SCHEDULE 1 AND 2",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 29,
+        "seatsUpperDeck": 45,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 25,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6500,
+              "gbWeight": 6300,
+              "kerbWeight": 4050,
+              "ladenWeight": 6525
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 11500,
+              "gbWeight": 11500,
+              "kerbWeight": 7700,
+              "ladenWeight": 11725
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON/TRANSBUS",
+        "bodyModel": "PRESIDENT",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "182202",
+        "brakes": {
+          "brakeCode": "182202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2920,
+            "secondaryBrakeForceA": 4106,
+            "serviceBrakeForceA": 8212
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1876,
+            "secondaryBrakeForceB": 2931,
+            "serviceBrakeForceB": 5862
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE 58",
+        "coifDate": "1999-11-25",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2016-09-07T14:30:16.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18000,
+        "grossGbWeight": 17800,
+        "grossKerbWeight": 11725,
+        "grossLadenWeight": 18250,
+        "lastUpdatedAt": "2022-03-15T17:46:36.238Z",
+        "lastUpdatedById": "70302477",
+        "lastUpdatedByName": "Evans, Richard",
+        "manufactureYear": 1999,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "12025",
+          "microfilmSerialNumber": "0451"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "0001-01-01",
+        "remarks": "W/CHAIR RAMP AND DRIVERS AIR CON\\nSEATS 45. 29 OR 27 AND 1 W/CHAIR AND 25 STANDEES\\nDDA SCHEDULE 1 AND 2\\nAUDIBLE ALARM FITTED TO WARN OF CAB DOOR OPEN AND HAND BRAKE IN THE 'OFF' POSITION",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 29,
+        "seatsUpperDeck": 45,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 25,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6500,
+              "gbWeight": 6300,
+              "kerbWeight": 4050,
+              "ladenWeight": 6525
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 11500,
+              "gbWeight": 11500,
+              "kerbWeight": 7700,
+              "ladenWeight": 11725
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON/TRANSBUS",
+        "bodyModel": "PRESIDENT",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "182202",
+        "brakes": {
+          "brakeCode": "182202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2920,
+            "secondaryBrakeForceA": 4106,
+            "serviceBrakeForceA": 8212
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1876,
+            "secondaryBrakeForceB": 2931,
+            "serviceBrakeForceB": 5862
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE 58",
+        "coifDate": "1999-11-25",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-15T17:46:36.238Z",
+        "createdById": "70302477",
+        "createdByName": "Doe, John",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m2",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18000,
+        "grossGbWeight": 17800,
+        "grossKerbWeight": 11725,
+        "grossLadenWeight": 18250,
+        "manufactureYear": 1999,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "12025",
+          "microfilmSerialNumber": "0451"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "0001-01-01",
+        "remarks": "W/CHAIR RAMP AND DRIVERS AIR CON\\nSEATS 45. 29 OR 27 AND 1 W/CHAIR AND 25 STANDEES\\nDDA SCHEDULE 1 AND 2\\nAUDIBLE ALARM FITTED TO WARN OF CAB DOOR OPEN AND HAND BRAKE IN THE 'OFF' POSITION",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 29,
+        "seatsUpperDeck": 45,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 25,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Part paid annual test retest, Test Type Id = 10, Vehicle = PSV",
+    "systemNumber": "3861534",
+    "vin": "SZAN4X20001858485",
+    "partialVin": "858485",
+    "primaryVrm": "YN57FXJ",
+    "secondaryVrms": ["601522Z"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 154,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 716,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 7100,
+              "gbWeight": 7100,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 716,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "OPTARE UK LTD/DARWEN",
+        "bodyModel": "DOUBLE DECK",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "179202",
+        "brakes": {
+          "brakeCode": "179202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2862,
+            "secondaryBrakeForceA": 4025,
+            "serviceBrakeForceA": 8050
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1926,
+            "secondaryBrakeForceB": 3010,
+            "serviceBrakeForceB": 6020
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "SCANIA",
+        "chassisModel": "N230UDEB",
+        "coifCertifierName": "JANE DOE N/WEST",
+        "coifDate": "2008-02-18",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2017-12-14T16:10:20.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 19100,
+        "grossGbWeight": 18000,
+        "grossKerbWeight": 12040,
+        "grossLadenWeight": 17890,
+        "lastUpdatedAt": "2022-03-17T13:38:52.231Z",
+        "lastUpdatedById": "70303553",
+        "lastUpdatedByName": "Keating, Jane",
+        "manufactureYear": 2008,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "08008",
+          "microfilmSerialNumber": "0433"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "complete",
+        "regnDate": "2008-02-19",
+        "remarks": "DDA SCH 1 & 2. SEATING 51 UPPER, LOWER 28 + 10 OR LOWER 26 + 1 W/CHAIR & 10 STANDING. MANUAL RAMP @ EXIT/INT TO THROTTLE & PARK RAMP, I/LOCKED TO THROTTLE KNEELING SUSPENSION RAISES ON RELEASE OF H/BRAKE ENGINE, G/BOX ENCAPSULATED WEIGHT. MAX GEARED SPEED 50MPH.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 28,
+        "seatsUpperDeck": 51,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 10,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 154,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 716,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 7100,
+              "gbWeight": 7100,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 716,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "OPTARE UK LTD/DARWEN",
+        "bodyModel": "DOUBLE DECK",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "179202",
+        "brakes": {
+          "brakeCode": "179202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2862,
+            "secondaryBrakeForceA": 4025,
+            "serviceBrakeForceA": 8050
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1926,
+            "secondaryBrakeForceB": 3010,
+            "serviceBrakeForceB": 6020
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "SCANIA",
+        "chassisModel": "N230UDEB",
+        "coifCertifierName": "JANE DOE N/WEST",
+        "coifDate": "2008-02-18",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-17T13:38:52.231Z",
+        "createdById": "70303553",
+        "createdByName": "Doe, Jane",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m2",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 19100,
+        "grossGbWeight": 18000,
+        "grossKerbWeight": 12040,
+        "grossLadenWeight": 17890,
+        "manufactureYear": 2008,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "08008",
+          "microfilmSerialNumber": "0433"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "complete",
+        "regnDate": "2008-02-19",
+        "remarks": "DDA SCH 1 & 2. SEATING 51 UPPER, LOWER 28 + 10 OR LOWER 26 + 1 W/CHAIR & 10 STANDING. MANUAL RAMP @ EXIT/INT TO THROTTLE & PARK RAMP, I/LOCKED TO THROTTLE KNEELING SUSPENSION RAISES ON RELEASE OF H/BRAKE ENGINE, G/BOX ENCAPSULATED WEIGHT. MAX GEARED SPEED 50MPH.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 28,
+        "seatsUpperDeck": 51,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 10,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Paid prohibition clearance (full inspection with certificate), Test Type ID = 14, Vehicle = PSV",
+    "systemNumber": "2958240",
+    "vin": "0H011144",
+    "partialVin": "011144",
+    "primaryVrm": "LJ53NGZ",
+    "secondaryVrms": ["404113Z"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 136,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 4480,
+              "gbWeight": 4480,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 134,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 8720,
+              "gbWeight": 8720,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "WRIGHTBUS/WRIGHT",
+        "bodyModel": "CADET",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "111202",
+        "brakes": {
+          "brakeCode": "111202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 1773,
+            "secondaryBrakeForceA": 2493,
+            "serviceBrakeForceA": 4986
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1232,
+            "secondaryBrakeForceB": 1925,
+            "serviceBrakeForceB": 3850
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "DAF",
+        "chassisModel": "SB120",
+        "coifCertifierName": "JOHN DOE",
+        "coifDate": "2003-10-14",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2016-01-29T12:49:33.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 12020,
+        "grossGbWeight": 12020,
+        "grossKerbWeight": 7700,
+        "grossLadenWeight": 11080,
+        "lastUpdatedAt": "2021-11-11T18:47:50.000000Z",
+        "manufactureYear": 2003,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "04009",
+          "microfilmSerialNumber": "0020"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "complete",
+        "regnDate": "0001-01-01",
+        "remarks": "UNRESTRAINED W/CHAIR. POWER RAMP FITTED UNDER EXIT DOOR, CONTROLS IN DRIVERS CAB. SEATING 23 & 28, 26 & 24 OR 23 SEATS & 1 W/CHAIR WITH 22 STANDEES. DDA PSVA2 SCHEDULES 1 & 2.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 23,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 28,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 136,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 4480,
+              "gbWeight": 4480,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 134,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 8720,
+              "gbWeight": 8720,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "WRIGHTBUS/WRIGHT",
+        "bodyModel": "CADET",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "111202",
+        "brakes": {
+          "brakeCode": "111202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 1773,
+            "secondaryBrakeForceA": 2493,
+            "serviceBrakeForceA": 4986
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1232,
+            "secondaryBrakeForceB": 1925,
+            "serviceBrakeForceB": 3850
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "DAF",
+        "chassisModel": "SB120",
+        "coifCertifierName": "JOHN DOE",
+        "coifDate": "2003-10-14",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2016-01-29T12:49:33.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 12020,
+        "grossGbWeight": 12020,
+        "grossKerbWeight": 7700,
+        "grossLadenWeight": 11080,
+        "lastUpdatedAt": "2022-03-11T12:48:57.202Z",
+        "lastUpdatedById": "70301545",
+        "lastUpdatedByName": "Charles, Daniel",
+        "manufactureYear": 2003,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "04009",
+          "microfilmSerialNumber": "0020"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "0001-01-01",
+        "remarks": "UNRESTRAINED W/CHAIR. POWER RAMP FITTED UNDER EXIT DOOR, CONTROLS IN DRIVERS CAB. SEATING 23 & 28, 26 & 24 OR 23 SEATS & 1 W/CHAIR WITH 22 STANDEES. DDA PSVA2 SCHEDULES 1 & 2. TACHO AND SPEED LIMITER",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 23,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": true,
+        "speedRestriction": 0,
+        "standingCapacity": 28,
+        "statusCode": "archived",
+        "tachoExemptMrk": true,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 136,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 4480,
+              "gbWeight": 4480,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 134,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 8720,
+              "gbWeight": 8720,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "WRIGHTBUS/WRIGHT",
+        "bodyModel": "CADET",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "111202",
+        "brakes": {
+          "brakeCode": "111202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 1773,
+            "secondaryBrakeForceA": 2493,
+            "serviceBrakeForceA": 4986
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1232,
+            "secondaryBrakeForceB": 1925,
+            "serviceBrakeForceB": 3850
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "DAF",
+        "chassisModel": "SB120",
+        "coifCertifierName": "JOHN DOE",
+        "coifDate": "2003-10-14",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-11T12:48:57.202Z",
+        "createdById": "70301545",
+        "createdByName": "Doe, Johnathan",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m3",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 12020,
+        "grossGbWeight": 12020,
+        "grossKerbWeight": 7700,
+        "grossLadenWeight": 11080,
+        "manufactureYear": 2003,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "04009",
+          "microfilmSerialNumber": "0020"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "0001-01-01",
+        "remarks": "UNRESTRAINED W/CHAIR. POWER RAMP FITTED UNDER EXIT DOOR, CONTROLS IN DRIVERS CAB. SEATING 23 & 28, 26 & 24 OR 23 SEATS & 1 W/CHAIR WITH 22 STANDEES. DDA PSVA2 SCHEDULES 1 & 2. TACHO AND SPEED LIMITER",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 23,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": true,
+        "speedRestriction": 0,
+        "standingCapacity": 28,
+        "statusCode": "current",
+        "tachoExemptMrk": true,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Paid prohibition clearance (retest with certificate), Test Type ID = 18, Vehicle = PSV",
+    "systemNumber": "3122473",
+    "vin": "YV3S2G5275A101304",
+    "partialVin": "101304",
+    "primaryVrm": "PO54ACJ",
+    "secondaryVrms": ["457182Z"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 152,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6900,
+              "gbWeight": 6300,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "DARWIN/EAST LANCS",
+        "bodyModel": "VYKING MILLENIUM",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "179202",
+        "brakes": {
+          "brakeCode": "179202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2860,
+            "secondaryBrakeForceA": 4022,
+            "serviceBrakeForceA": 8044
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1955,
+            "secondaryBrakeForceB": 3055,
+            "serviceBrakeForceB": 6110
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE",
+        "coifDate": "2004-09-06",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2016-09-19T15:03:07.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18900,
+        "grossGbWeight": 17800,
+        "grossKerbWeight": 12220,
+        "grossLadenWeight": 17875,
+        "lastUpdatedAt": "2022-03-15T17:46:53.393Z",
+        "lastUpdatedById": "70300386",
+        "lastUpdatedByName": "Hopkins, Tracy",
+        "manufactureYear": 2004,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "04137",
+          "microfilmSerialNumber": "0333"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "complete",
+        "regnDate": "2004-08-23",
+        "remarks": "DDA PSVA S SCH 1+2, DRV ONLY A/C, PWR RAMP @ EXT + INTLCK ENT DOOR, KNEEL SUSP. INTLCK, 47 UPPER, 22 LOWER + 1 W/CHAIR, OR 22 + 16",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 22,
+        "seatsUpperDeck": 47,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 16,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 152,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6900,
+              "gbWeight": 6300,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "DARWIN/EAST LANCS",
+        "bodyModel": "VYKING MILLENIUM",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "179202",
+        "brakes": {
+          "brakeCode": "179202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2860,
+            "secondaryBrakeForceA": 4022,
+            "serviceBrakeForceA": 8044
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1955,
+            "secondaryBrakeForceB": 3055,
+            "serviceBrakeForceB": 6110
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE",
+        "coifDate": "2004-09-06",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-15T17:46:53.393Z",
+        "createdById": "70300386",
+        "createdByName": "Doe, Jane",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m2",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18900,
+        "grossGbWeight": 17800,
+        "grossKerbWeight": 12220,
+        "grossLadenWeight": 17875,
+        "manufactureYear": 2004,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "04137",
+          "microfilmSerialNumber": "0333"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "complete",
+        "regnDate": "2004-08-23",
+        "remarks": "DDA PSVA S SCH 1+2, DRV ONLY A/C, PWR RAMP @ EXT + INTLCK ENT DOOR, KNEEL SUSP. INTLCK, 47 UPPER, 22 LOWER + 1 W/CHAIR, OR 22 + 16",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 22,
+        "seatsUpperDeck": 47,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 16,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Part-paid prohibition clearance (retest with certificate), Test Type ID = 21, Vehicle = PSV",
+    "systemNumber": "1026750",
+    "vin": "YS4ND4X2B01817469",
+    "partialVin": "817469",
+    "primaryVrm": "H219LOM",
+    "secondaryVrms": [" "],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 146,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 316,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6500,
+              "gbWeight": 6000,
+              "kerbWeight": 3360,
+              "ladenWeight": 5438
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 144,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 316,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 11000,
+              "gbWeight": 10500,
+              "kerbWeight": 6920,
+              "ladenWeight": 10757
+            }
+          }
+        ],
+        "bodyMake": "ALEXANDER",
+        "bodyModel": "RH",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "162222",
+        "brakes": {
+          "brakeCode": "162222",
+          "brakeCodeOriginal": "222",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2591,
+            "secondaryBrakeForceA": 3644,
+            "serviceBrakeForceA": 7288
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1645,
+            "secondaryBrakeForceB": 2570,
+            "serviceBrakeForceB": 5140
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle Secondary brake on axle 2",
+          "retarderBrakeOne": "none",
+          "retarderBrakeTwo": "hydraulic"
+        },
+        "chassisMake": "SCANIA",
+        "chassisModel": "ND",
+        "coifCertifierName": " ",
+        "coifDate": "1990-09-20",
+        "coifSerialNumber": "0",
+        "conversionRefNo": " ",
+        "createdAt": "2014-07-29T16:50:27.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 17500,
+        "grossGbWeight": 16500,
+        "grossKerbWeight": 10280,
+        "grossLadenWeight": 16195,
+        "lastUpdatedAt": "2021-11-11T18:47:50.000000Z",
+        "manufactureYear": 1990,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "07100",
+          "microfilmSerialNumber": "0039"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": " ",
+        "recordCompleteness": "testable",
+        "regnDate": "1990-09-24",
+        "remarks": " ",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 31,
+        "seatsUpperDeck": 45,
+        "speedLimiterMrk": false,
+        "speedRestriction": 50,
+        "standingCapacity": 14,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 146,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 316,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6500,
+              "gbWeight": 6000,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 144,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 316,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 11000,
+              "gbWeight": 10500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "ALEXANDER",
+        "bodyModel": "RH",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "172222",
+        "brakes": {
+          "brakeCode": "172222",
+          "brakeCodeOriginal": "222",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2746,
+            "secondaryBrakeForceA": 3862,
+            "serviceBrakeForceA": 7724
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1654,
+            "secondaryBrakeForceB": 2585,
+            "serviceBrakeForceB": 5170
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle Secondary brake on axle 2",
+          "retarderBrakeOne": "none",
+          "retarderBrakeTwo": "hydraulic"
+        },
+        "chassisMake": "SCANIA",
+        "chassisModel": "ND",
+        "coifCertifierName": " ",
+        "coifDate": "1990-09-20",
+        "coifSerialNumber": "0",
+        "conversionRefNo": " ",
+        "createdAt": "2014-07-29T16:50:27.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 17500,
+        "grossGbWeight": 16500,
+        "grossKerbWeight": 10340,
+        "grossLadenWeight": 17165,
+        "lastUpdatedAt": "2022-03-15T17:39:29.831Z",
+        "lastUpdatedById": "70302477",
+        "lastUpdatedByName": "Evans, Richard",
+        "manufactureYear": 1990,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "07100",
+          "microfilmSerialNumber": "0039"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "1990-09-24",
+        "remarks": "PSVCA40 INCREASE CARRYING CAPACITY",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 31,
+        "seatsUpperDeck": 45,
+        "speedLimiterMrk": false,
+        "speedRestriction": 50,
+        "standingCapacity": 14,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 146,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 316,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6500,
+              "gbWeight": 6000,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 144,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 316,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 11000,
+              "gbWeight": 10500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "ALEXANDER",
+        "bodyModel": "RH",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "172222",
+        "brakes": {
+          "brakeCode": "172222",
+          "brakeCodeOriginal": "222",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2746,
+            "secondaryBrakeForceA": 3862,
+            "serviceBrakeForceA": 7724
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1654,
+            "secondaryBrakeForceB": 2585,
+            "serviceBrakeForceB": 5170
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle Secondary brake on axle 2",
+          "retarderBrakeOne": "none",
+          "retarderBrakeTwo": "hydraulic"
+        },
+        "chassisMake": "SCANIA",
+        "chassisModel": "ND",
+        "coifCertifierName": " ",
+        "coifDate": "1990-09-20",
+        "coifSerialNumber": "0",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-15T17:39:29.831Z",
+        "createdById": "70302477",
+        "createdByName": "Doe, John",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m3",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 17500,
+        "grossGbWeight": 16500,
+        "grossKerbWeight": 10340,
+        "grossLadenWeight": 17165,
+        "manufactureYear": 1990,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "07100",
+          "microfilmSerialNumber": "0039"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "1990-09-24",
+        "remarks": "PSVCA40 INCREASE CARRYING CAPACITY",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 31,
+        "seatsUpperDeck": 45,
+        "speedLimiterMrk": false,
+        "speedRestriction": 50,
+        "standingCapacity": 14,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Paid prohibition clearance with Class 6A seatbelt installation check (full inspection), Test Type ID = 27, Vehicle = PSV",
+    "systemNumber": "1572692",
+    "vin": "YV31M2B16RA041798",
+    "partialVin": "041798",
+    "primaryVrm": "M534CEY",
+    "secondaryVrms": ["VLT290"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 156,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "l",
+              "tyreCode": 428,
+              "tyreSize": "315/80-22.5"
+            },
+            "weights": {
+              "designWeight": 7500,
+              "gbWeight": 7500,
+              "kerbWeight": 5940,
+              "ladenWeight": 7320
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 150,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "l",
+              "tyreCode": 428,
+              "tyreSize": "315/80-22.5"
+            },
+            "weights": {
+              "designWeight": 10500,
+              "gbWeight": 10500,
+              "kerbWeight": 6930,
+              "ladenWeight": 9675
+            }
+          }
+        ],
+        "bodyMake": "JONCKHEERE",
+        "bodyModel": "DEAUVILLE",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "170202",
+        "brakes": {
+          "brakeCode": "170202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2719,
+            "secondaryBrakeForceA": 3824,
+            "serviceBrakeForceA": 7648
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 2059,
+            "secondaryBrakeForceB": 3218,
+            "serviceBrakeForceB": 6435
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "exhaust",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B10M",
+        "coifCertifierName": " ",
+        "coifDate": "1994-09-15",
+        "coifSerialNumber": "0",
+        "conversionRefNo": " ",
+        "createdAt": "2013-10-24T09:07:28.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18000,
+        "grossGbWeight": 17000,
+        "grossKerbWeight": 12870,
+        "grossLadenWeight": 16995,
+        "lastUpdatedAt": "2022-03-15T17:34:08.618Z",
+        "lastUpdatedById": "70302477",
+        "lastUpdatedByName": "Evans, Richard",
+        "manufactureYear": 1994,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "00102",
+          "microfilmSerialNumber": "0155"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "1995-02-01",
+        "remarks": "DUAL SEATING 53/51  GROSS LADEN WEIGHT CRITICAL03039890Z",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 53,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": true,
+        "speedRestriction": 0,
+        "standingCapacity": 0,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 156,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "l",
+              "tyreCode": 428,
+              "tyreSize": "315/80-22.5"
+            },
+            "weights": {
+              "designWeight": 7500,
+              "gbWeight": 7500,
+              "kerbWeight": 5940,
+              "ladenWeight": 7320
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 150,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "l",
+              "tyreCode": 428,
+              "tyreSize": "315/80-22.5"
+            },
+            "weights": {
+              "designWeight": 10500,
+              "gbWeight": 10500,
+              "kerbWeight": 6930,
+              "ladenWeight": 9675
+            }
+          }
+        ],
+        "bodyMake": "JONCKHEERE",
+        "bodyModel": "DEAUVILLE",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "170202",
+        "brakes": {
+          "brakeCode": "170202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2719,
+            "secondaryBrakeForceA": 3824,
+            "serviceBrakeForceA": 7648
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 2059,
+            "secondaryBrakeForceB": 3218,
+            "serviceBrakeForceB": 6435
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "exhaust",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B10M",
+        "coifCertifierName": " ",
+        "coifDate": "1994-09-15",
+        "coifSerialNumber": "0",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-15T17:34:08.618Z",
+        "createdById": "70302477",
+        "createdByName": "Doe, John",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m3",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18000,
+        "grossGbWeight": 17000,
+        "grossKerbWeight": 12870,
+        "grossLadenWeight": 16995,
+        "manufactureYear": 1994,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "00102",
+          "microfilmSerialNumber": "0155"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "1995-02-01",
+        "remarks": "DUAL SEATING 53/51  GROSS LADEN WEIGHT CRITICAL03039890Z",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 53,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": true,
+        "speedRestriction": 0,
+        "standingCapacity": 0,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Prohibition clearance (retest with Class 6A seatbelt installation check), Test Type ID = 28, Vehicle = PSV",
+    "systemNumber": "2541700",
+    "vin": "YV3S2C6111A001336",
+    "partialVin": "001336",
+    "primaryVrm": "X508EGK",
+    "secondaryVrms": ["262723Z"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6900,
+              "gbWeight": 6900,
+              "kerbWeight": 3910,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11500,
+              "kerbWeight": 7620,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON/TRANSBUS",
+        "bodyModel": "PRESIDENT",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "172202",
+        "brakes": {
+          "brakeCode": "172202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2750,
+            "secondaryBrakeForceA": 3867,
+            "serviceBrakeForceA": 7733
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1845,
+            "secondaryBrakeForceB": 2882,
+            "serviceBrakeForceB": 5765
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE 58",
+        "coifDate": "2001-01-04",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2019-05-20T13:31:07.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18000,
+        "grossGbWeight": 18000,
+        "grossKerbWeight": 11530,
+        "grossLadenWeight": 17185,
+        "lastUpdatedAt": "2021-11-11T18:47:50.000000Z",
+        "manufactureYear": 2000,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "12025",
+          "microfilmSerialNumber": "0271"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "2001-01-23",
+        "remarks": "W/CHAIR RAMP AND DRIVERS AIR CON\\nSEATS 41, 23 OR 20 AND 1 W/CHAIR AND 22 STANDEES\\nPSVA2 SCHEDULES 1 AND 2",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 23,
+        "seatsUpperDeck": 41,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 22,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6900,
+              "gbWeight": 6900,
+              "kerbWeight": 3910,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11500,
+              "kerbWeight": 7620,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON/TRANSBUS",
+        "bodyModel": "PRESIDENT",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "172202",
+        "brakes": {
+          "brakeCode": "172202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2750,
+            "secondaryBrakeForceA": 3867,
+            "serviceBrakeForceA": 7733
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1845,
+            "secondaryBrakeForceB": 2882,
+            "serviceBrakeForceB": 5765
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE 58",
+        "coifDate": "2001-01-04",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2019-05-20T13:31:07.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18000,
+        "grossGbWeight": 18000,
+        "grossKerbWeight": 11530,
+        "grossLadenWeight": 17185,
+        "lastUpdatedAt": "2021-11-11T18:47:50.000000Z",
+        "manufactureYear": 2000,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "12025",
+          "microfilmSerialNumber": "0271"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "2001-01-23",
+        "remarks": "W/CHAIR RAMP AND DRIVERS AIR CON\\nSEATS 41, 23 OR 20 AND 1 W/CHAIR AND 22 STANDEES\\nPSVA2 SCHEDULES 1 AND 2\\nNEW SEATPLAN",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 23,
+        "seatsUpperDeck": 41,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 22,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6900,
+              "gbWeight": 6900,
+              "kerbWeight": 3910,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11500,
+              "kerbWeight": 7620,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON/TRANSBUS",
+        "bodyModel": "PRESIDENT",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "172202",
+        "brakes": {
+          "brakeCode": "172202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2750,
+            "secondaryBrakeForceA": 3867,
+            "serviceBrakeForceA": 7733
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1845,
+            "secondaryBrakeForceB": 2882,
+            "serviceBrakeForceB": 5765
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE 58",
+        "coifDate": "2001-01-04",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2019-05-20T13:31:07.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18000,
+        "grossGbWeight": 18000,
+        "grossKerbWeight": 11530,
+        "grossLadenWeight": 17185,
+        "lastUpdatedAt": "2021-11-11T18:47:50.000000Z",
+        "manufactureYear": 2000,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "12025",
+          "microfilmSerialNumber": "0271"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "2001-01-23",
+        "remarks": "W/CHAIR RAMP AND DRIVERS AIR CON\\nSEATS 41, 23 OR 20 AND 1 W/CHAIR AND 22 STANDEES\\nPSVA2 SCHEDULES 1 AND 2\\nNEW SEATPLAN",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 23,
+        "seatsUpperDeck": 41,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 22,
+        "statusCode": "archived",
+        "tachoExemptMrk": true,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6900,
+              "gbWeight": 6900,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON/TRANSBUS",
+        "bodyModel": "PRESIDENT",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "brakeCode": "178202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2855,
+            "secondaryBrakeForceA": 4015,
+            "serviceBrakeForceA": 8030
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1910,
+            "secondaryBrakeForceB": 2985,
+            "serviceBrakeForceB": 5970
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE 58",
+        "coifDate": "2001-01-04",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2019-05-20T13:31:07.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18000,
+        "grossGbWeight": 18000,
+        "grossKerbWeight": 11940,
+        "grossLadenWeight": 17844,
+        "lastUpdatedAt": "2022-03-15T18:02:16.477Z",
+        "lastUpdatedById": "70300386",
+        "lastUpdatedByName": "Hopkins, Tracy",
+        "manufactureYear": 2000,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "12025",
+          "microfilmSerialNumber": "0271"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "2001-01-23",
+        "remarks": "W/CHAIR RAMP AND DRIVERS AIR CON\\nSEATS 41, 23 OR 20 AND 1 W/CHAIR AND 22 STANDEES\\nPSVA2 SCHEDULES 1 AND 2\\nNEW SEATPLAN\\nPSVCA40 - INCREASE CARRYING CAPACITY. CENTRE DOORS REMOVED AND RAMP MOVED TO FRONT ENTRANCE. DDA 1 AND 2 RETAINED. INTERLOCKED ON RAMP AND KNEELING SUSPENSION. 41 UPPER, LOWER 27 SEATED AND 22 STANDING OR 25 SEATED AND 22 STANDING WITH 1 W/C",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 27,
+        "seatsUpperDeck": 41,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 22,
+        "statusCode": "archived",
+        "tachoExemptMrk": true,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6900,
+              "gbWeight": 6900,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON/TRANSBUS",
+        "bodyModel": "PRESIDENT",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "brakeCode": "178202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2855,
+            "secondaryBrakeForceA": 4015,
+            "serviceBrakeForceA": 8030
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1910,
+            "secondaryBrakeForceB": 2985,
+            "serviceBrakeForceB": 5970
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE 58",
+        "coifDate": "2001-01-04",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-15T18:02:16.477Z",
+        "createdById": "70300386",
+        "createdByName": "Doe, Jane",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m2",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18000,
+        "grossGbWeight": 18000,
+        "grossKerbWeight": 11940,
+        "grossLadenWeight": 17844,
+        "manufactureYear": 2000,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "12025",
+          "microfilmSerialNumber": "0271"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "2001-01-23",
+        "remarks": "W/CHAIR RAMP AND DRIVERS AIR CON\\nSEATS 41, 23 OR 20 AND 1 W/CHAIR AND 22 STANDEES\\nPSVA2 SCHEDULES 1 AND 2\\nNEW SEATPLAN\\nPSVCA40 - INCREASE CARRYING CAPACITY. CENTRE DOORS REMOVED AND RAMP MOVED TO FRONT ENTRANCE. DDA 1 AND 2 RETAINED. INTERLOCKED ON RAMP AND KNEELING SUSPENSION. 41 UPPER, LOWER 27 SEATED AND 22 STANDING OR 25 SEATED AND 22 STANDING WITH 1 W/C",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 27,
+        "seatsUpperDeck": 41,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 22,
+        "statusCode": "current",
+        "tachoExemptMrk": true,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Prohibition clearance (retest without Class 6A seatbelt installation check), Test Type ID = 93, Vehicle = PSV",
+    "systemNumber": "2426598",
+    "vin": "XGW14269",
+    "partialVin": "W14269",
+    "primaryVrm": "W363ABD",
+    "secondaryVrms": ["229578Z"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 136,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 4500,
+              "gbWeight": 4360,
+              "kerbWeight": 1990,
+              "ladenWeight": 2916
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 134,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 8000,
+              "gbWeight": 8000,
+              "kerbWeight": 4610,
+              "ladenWeight": 6804
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON/TRANSBUS",
+        "bodyModel": "POINTER",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "097202",
+        "brakes": {
+          "brakeCode": "097202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 1555,
+            "secondaryBrakeForceA": 2187,
+            "serviceBrakeForceA": 4374
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1056,
+            "secondaryBrakeForceB": 1650,
+            "serviceBrakeForceB": 3300
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "DENNIS/TRANSBUS",
+        "chassisModel": "DART",
+        "coifCertifierName": "JOHN DOE 41",
+        "coifDate": "2000-01-25",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2017-02-06T10:19:41.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 11000,
+        "grossGbWeight": 11000,
+        "grossKerbWeight": 6600,
+        "grossLadenWeight": 9720,
+        "lastUpdatedAt": "2022-07-14T19:17:14.659Z",
+        "lastUpdatedById": "70302477",
+        "lastUpdatedByName": "Evans, Richard",
+        "manufactureYear": 1999,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "00094",
+          "microfilmSerialNumber": "0048"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "2000-04-25",
+        "remarks": "KNEELING SYSTEM ON FRONT SUSPENSION, HANDBRAKE INTERLOCK, MANUAL WHEELCHAIR RAMP AT EN/EX.2X LUGGAGE PENS, SEAT 26 WITH 21 STANDEES OR 29 WITH 17 OR 26 WITH 17 AND 1 WHEELCHAIR, MAX GEARED SPEED 60MPH",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 26,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 21,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 136,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 4500,
+              "gbWeight": 4360,
+              "kerbWeight": 1990,
+              "ladenWeight": 2916
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 134,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 8000,
+              "gbWeight": 8000,
+              "kerbWeight": 4610,
+              "ladenWeight": 6804
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON/TRANSBUS",
+        "bodyModel": "POINTER",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "097202",
+        "brakes": {
+          "brakeCode": "097202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 1555,
+            "secondaryBrakeForceA": 2187,
+            "serviceBrakeForceA": 4374
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1056,
+            "secondaryBrakeForceB": 1650,
+            "serviceBrakeForceB": 3300
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "DENNIS/TRANSBUS",
+        "chassisModel": "DART",
+        "coifCertifierName": "JOHN DOE 41",
+        "coifDate": "2000-01-25",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-07-14T19:17:14.659Z",
+        "createdById": "70302477",
+        "createdByName": "Doe, John",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m2",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 11000,
+        "grossGbWeight": 11000,
+        "grossKerbWeight": 6600,
+        "grossLadenWeight": 9720,
+        "manufactureYear": 1999,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "00094",
+          "microfilmSerialNumber": "0048"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "2000-04-25",
+        "remarks": "KNEELING SYSTEM ON FRONT SUSPENSION, HANDBRAKE INTERLOCK, MANUAL WHEELCHAIR RAMP AT EN/EX.2X LUGGAGE PENS, SEAT 26 WITH 21 STANDEES OR 29 WITH 17 OR 26 WITH 17 AND 1 WHEELCHAIR, MAX GEARED SPEED 60MPH",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 26,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 21,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Paid prohibition clearance (full inspection without certificate), Test Type ID = 15, Vehicle = PSV",
+    "systemNumber": "2125638",
+    "vin": "WGW13005",
+    "partialVin": "W13005",
+    "primaryVrm": "T440EBD",
+    "secondaryVrms": ["124385Z"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 136,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 4500,
+              "gbWeight": 4360,
+              "kerbWeight": 2430,
+              "ladenWeight": 4014
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 134,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 8000,
+              "gbWeight": 8000,
+              "kerbWeight": 4403,
+              "ladenWeight": 6914
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON/TRANSBUS",
+        "bodyModel": "POINTER",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "109202",
+        "brakes": {
+          "brakeCode": "109202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 1748,
+            "secondaryBrakeForceA": 2459,
+            "serviceBrakeForceA": 4918
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1093,
+            "secondaryBrakeForceB": 1708,
+            "serviceBrakeForceB": 3416
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "DENNIS/TRANSBUS",
+        "chassisModel": "DART",
+        "coifCertifierName": "JOHN DOE",
+        "coifDate": "1999-02-18",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2014-12-02T15:19:39.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 11500,
+        "grossGbWeight": 11500,
+        "grossKerbWeight": 6833,
+        "grossLadenWeight": 10928,
+        "lastUpdatedAt": "2022-03-15T17:24:36.090Z",
+        "lastUpdatedById": "70300386",
+        "lastUpdatedByName": "Hopkins, Tracy",
+        "manufactureYear": 1999,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "99037",
+          "microfilmSerialNumber": "0027"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "1999-04-09",
+        "remarks": "MAX GEARED SPEED 60.KNEELING SYSTEM FITTED TO FRONT SUSPENSION.HANDBRAKE INTERLOCK.WHEELCHAIR RAMP FITTED WITH DOOR INTERLOCK.2 LUGGAGE PENS.36 SEATED PLUS ONE WHEELCHAIR WITH 22 STANDEES\\nOR 36 SEATED WITH 26 STANDEES OR 39 SEATED WITH 22 STANDEES.\\nREPLACEMENT VTP20 ISSUED 25/04/2008 CERT NO HZ7914U\\nREPLACEMENT VTP20 ISSUED 25/04/2008 CERT NO HZ7914U",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 36,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 26,
+        "statusCode": "archived",
+        "tachoExemptMrk": true,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 136,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 4500,
+              "gbWeight": 4360,
+              "kerbWeight": 2430,
+              "ladenWeight": 4014
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 134,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 715,
+              "tyreSize": "245/70-19.5"
+            },
+            "weights": {
+              "designWeight": 8000,
+              "gbWeight": 8000,
+              "kerbWeight": 4403,
+              "ladenWeight": 6914
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON/TRANSBUS",
+        "bodyModel": "POINTER",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "109202",
+        "brakes": {
+          "brakeCode": "109202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 1748,
+            "secondaryBrakeForceA": 2459,
+            "serviceBrakeForceA": 4918
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1093,
+            "secondaryBrakeForceB": 1708,
+            "serviceBrakeForceB": 3416
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "DENNIS/TRANSBUS",
+        "chassisModel": "DART",
+        "coifCertifierName": "JOHN DOE",
+        "coifDate": "1999-02-18",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-15T17:24:36.090Z",
+        "createdById": "70300386",
+        "createdByName": "Doe, Jane",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m2",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 11500,
+        "grossGbWeight": 11500,
+        "grossKerbWeight": 6833,
+        "grossLadenWeight": 10928,
+        "manufactureYear": 1999,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "99037",
+          "microfilmSerialNumber": "0027"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "1999-04-09",
+        "remarks": "MAX GEARED SPEED 60.KNEELING SYSTEM FITTED TO FRONT SUSPENSION.HANDBRAKE INTERLOCK.WHEELCHAIR RAMP FITTED WITH DOOR INTERLOCK.2 LUGGAGE PENS.36 SEATED PLUS ONE WHEELCHAIR WITH 22 STANDEES\\nOR 36 SEATED WITH 26 STANDEES OR 39 SEATED WITH 22 STANDEES.\\nREPLACEMENT VTP20 ISSUED 25/04/2008 CERT NO HZ7914U\\nREPLACEMENT VTP20 ISSUED 25/04/2008 CERT NO HZ7914U",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 36,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 26,
+        "statusCode": "current",
+        "tachoExemptMrk": true,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Part paid prohibition clearance (full inspection without certificate), Test Type ID = 16, Vehicle = PSV",
+    "systemNumber": "1223778",
+    "vin": "YV3YNA411WC029092",
+    "partialVin": "029092",
+    "primaryVrm": "S148KNK",
+    "secondaryVrms": ["093467Z"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "l",
+              "tyreCode": 438,
+              "tyreSize": "11-22.5"
+            },
+            "weights": {
+              "designWeight": 6500,
+              "gbWeight": 6300,
+              "kerbWeight": 3860,
+              "ladenWeight": 6156
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "l",
+              "tyreCode": 438,
+              "tyreSize": "11-22.5"
+            },
+            "weights": {
+              "designWeight": 11000,
+              "gbWeight": 10500,
+              "kerbWeight": 7179,
+              "ladenWeight": 10473
+            }
+          }
+        ],
+        "bodyMake": "NORTHERN COUNTIES",
+        "bodyModel": "PALATINE II",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "166202",
+        "brakes": {
+          "brakeCode": "166202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2661,
+            "secondaryBrakeForceA": 3742,
+            "serviceBrakeForceA": 7483
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1766,
+            "secondaryBrakeForceB": 2760,
+            "serviceBrakeForceB": 5520
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "LEYLAND/VOLVO",
+        "chassisModel": "OLYMPIAN",
+        "coifCertifierName": " ",
+        "coifDate": "1998-07-04",
+        "coifSerialNumber": "0",
+        "conversionRefNo": " ",
+        "createdAt": "2013-11-08T08:43:55.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 17000,
+        "grossGbWeight": 16800,
+        "grossKerbWeight": 11039,
+        "grossLadenWeight": 16629,
+        "lastUpdatedAt": "2022-03-15T17:27:27.185Z",
+        "lastUpdatedById": "70300386",
+        "lastUpdatedByName": "Hopkins, Tracy",
+        "manufactureYear": 1998,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": null,
+          "microfilmRollNumber": null,
+          "microfilmSerialNumber": null
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": " ",
+        "recordCompleteness": "testable",
+        "regnDate": "1998-08-01",
+        "remarks": "MAX GEARED SPEED 60MPH",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 29,
+        "seatsUpperDeck": 39,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 17,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "l",
+              "tyreCode": 438,
+              "tyreSize": "11-22.5"
+            },
+            "weights": {
+              "designWeight": 6500,
+              "gbWeight": 6300,
+              "kerbWeight": 3860,
+              "ladenWeight": 6156
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "l",
+              "tyreCode": 438,
+              "tyreSize": "11-22.5"
+            },
+            "weights": {
+              "designWeight": 11000,
+              "gbWeight": 10500,
+              "kerbWeight": 7179,
+              "ladenWeight": 10473
+            }
+          }
+        ],
+        "bodyMake": "NORTHERN COUNTIES",
+        "bodyModel": "PALATINE II",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "166202",
+        "brakes": {
+          "brakeCode": "166202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2661,
+            "secondaryBrakeForceA": 3742,
+            "serviceBrakeForceA": 7483
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1766,
+            "secondaryBrakeForceB": 2760,
+            "serviceBrakeForceB": 5520
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "LEYLAND/VOLVO",
+        "chassisModel": "OLYMPIAN",
+        "coifCertifierName": " ",
+        "coifDate": "1998-07-04",
+        "coifSerialNumber": "0",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-15T17:27:27.185Z",
+        "createdById": "70300386",
+        "createdByName": "Doe, Jane",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m3",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 17000,
+        "grossGbWeight": 16800,
+        "grossKerbWeight": 11039,
+        "grossLadenWeight": 16629,
+        "manufactureYear": 1998,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": null,
+          "microfilmRollNumber": null,
+          "microfilmSerialNumber": null
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": " ",
+        "recordCompleteness": "testable",
+        "regnDate": "1998-08-01",
+        "remarks": "MAX GEARED SPEED 60MPH",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 29,
+        "seatsUpperDeck": 39,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 17,
+        "statusCode": "provisional",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Part-paid prohibition clearance (partial inspection without certificate), Test Type ID = 23, Vehicle = PSV",
+    "systemNumber": "1822096",
+    "vin": "WDB6690032N049933",
+    "partialVin": "049933",
+    "primaryVrm": "P334TGS",
+    "secondaryVrms": ["074147Z"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 121,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "n",
+              "tyreCode": 412,
+              "tyreSize": "225/75-16"
+            },
+            "weights": {
+              "designWeight": 2300,
+              "gbWeight": 2300,
+              "kerbWeight": 1910,
+              "ladenWeight": 1995
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 120,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "n",
+              "tyreCode": 412,
+              "tyreSize": "225/75-16"
+            },
+            "weights": {
+              "designWeight": 4300,
+              "gbWeight": 4300,
+              "kerbWeight": 2450,
+              "ladenWeight": 3470
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON",
+        "bodyModel": "BEAVER",
+        "bodyType": {
+          "code": "m",
+          "description": "other"
+        },
+        "brakeCode": "055202",
+        "brakes": {
+          "brakeCode": "055202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 874,
+            "secondaryBrakeForceA": 1230,
+            "serviceBrakeForceA": 2459
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 698,
+            "secondaryBrakeForceB": 1090,
+            "serviceBrakeForceB": 2180
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "exhaust",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "MERCEDES",
+        "chassisModel": "711D",
+        "coifCertifierName": " ",
+        "coifDate": "1997-04-03",
+        "coifSerialNumber": "0",
+        "conversionRefNo": " ",
+        "createdAt": "2013-03-12T13:15:05.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 6400,
+        "grossGbWeight": 6400,
+        "grossKerbWeight": 4360,
+        "grossLadenWeight": 5465,
+        "lastUpdatedAt": "2021-11-11T18:47:50.000000Z",
+        "manufactureYear": 1997,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "07100",
+          "microfilmSerialNumber": "0038"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": " ",
+        "recordCompleteness": "testable",
+        "regnDate": "1997-04-17",
+        "remarks": "SEATING 16 OR 4 SEATS & 4 WHEELCHAIRS.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 16,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 0,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "small",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 121,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "n",
+              "tyreCode": 412,
+              "tyreSize": "225/75-16"
+            },
+            "weights": {
+              "designWeight": 2300,
+              "gbWeight": 2300,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 120,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "n",
+              "tyreCode": 412,
+              "tyreSize": "225/75-16"
+            },
+            "weights": {
+              "designWeight": 4300,
+              "gbWeight": 4300,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON",
+        "bodyModel": "BEAVER",
+        "bodyType": {
+          "code": "m",
+          "description": "other"
+        },
+        "brakeCode": "061202",
+        "brakes": {
+          "brakeCode": "061202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 972,
+            "secondaryBrakeForceA": 1367,
+            "serviceBrakeForceA": 2734
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 712,
+            "secondaryBrakeForceB": 1112,
+            "serviceBrakeForceB": 2225
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "exhaust",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "MERCEDES",
+        "chassisModel": "711D",
+        "coifCertifierName": " ",
+        "coifDate": "1997-04-03",
+        "coifSerialNumber": "0",
+        "conversionRefNo": " ",
+        "createdAt": "2013-03-12T13:15:05.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 6400,
+        "grossGbWeight": 6400,
+        "grossKerbWeight": 4450,
+        "grossLadenWeight": 6075,
+        "lastUpdatedAt": "2022-03-15T17:31:31.368Z",
+        "lastUpdatedById": "70300386",
+        "lastUpdatedByName": "Hopkins, Tracy",
+        "manufactureYear": 1997,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "07100",
+          "microfilmSerialNumber": "0038"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "1997-04-17",
+        "remarks": "PSVCA40 INCREASE CARRYING CAPACITY",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 24,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 0,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 121,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "n",
+              "tyreCode": 412,
+              "tyreSize": "225/75-16"
+            },
+            "weights": {
+              "designWeight": 2300,
+              "gbWeight": 2300,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 120,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "n",
+              "tyreCode": 412,
+              "tyreSize": "225/75-16"
+            },
+            "weights": {
+              "designWeight": 4300,
+              "gbWeight": 4300,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON",
+        "bodyModel": "BEAVER",
+        "bodyType": {
+          "code": "m",
+          "description": "other"
+        },
+        "brakeCode": "061202",
+        "brakes": {
+          "brakeCode": "061202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 972,
+            "secondaryBrakeForceA": 1367,
+            "serviceBrakeForceA": 2734
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 712,
+            "secondaryBrakeForceB": 1112,
+            "serviceBrakeForceB": 2225
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "exhaust",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "MERCEDES",
+        "chassisModel": "711D",
+        "coifCertifierName": " ",
+        "coifDate": "1997-04-03",
+        "coifSerialNumber": "0",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-15T17:31:31.368Z",
+        "createdById": "70300386",
+        "createdByName": "Doe, Jane",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m2",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 6400,
+        "grossGbWeight": 6400,
+        "grossKerbWeight": 4450,
+        "grossLadenWeight": 6075,
+        "manufactureYear": 1997,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "PSV N/ALT",
+          "microfilmRollNumber": "07100",
+          "microfilmSerialNumber": "0038"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "VTP5",
+        "recordCompleteness": "complete",
+        "regnDate": "1997-04-17",
+        "remarks": "PSVCA40 INCREASE CARRYING CAPACITY",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 24,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 0,
+        "statusCode": "provisional",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Paid prohibition clearance (retest without certificate), Test Type ID = 19, Vehicle = PSV",
+    "systemNumber": "3128310",
+    "vin": "YV3S2G5265A101407",
+    "partialVin": "101407",
+    "primaryVrm": "PO54ACV",
+    "secondaryVrms": ["459062Z"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 152,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6900,
+              "gbWeight": 6300,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "DARWIN/EAST LANCS",
+        "bodyModel": "VYKING MYLLENIUM",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "179202",
+        "brakes": {
+          "brakeCode": "179202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2860,
+            "secondaryBrakeForceA": 4022,
+            "serviceBrakeForceA": 8044
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1955,
+            "secondaryBrakeForceB": 3055,
+            "serviceBrakeForceB": 6110
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE N/WEST",
+        "coifDate": "2004-09-15",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2016-10-06T09:49:52.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18900,
+        "grossGbWeight": 17800,
+        "grossKerbWeight": 12220,
+        "grossLadenWeight": 17875,
+        "lastUpdatedAt": "2022-03-18T16:14:55.209Z",
+        "lastUpdatedById": "70302477",
+        "lastUpdatedByName": "Evans, Richard",
+        "manufactureYear": 2004,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "04121",
+          "microfilmSerialNumber": "0223"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "complete",
+        "regnDate": "2004-08-23",
+        "remarks": "DDA PSVA2 SCHEDULE 1 & 2. DRIVER ONLY AIR CONDITIONING. POWER RAMP AT EXIT & INTERLOCKED ENTRANCE DOORS. KNEEL SUSPENSION & INTERLOCKED.\\nSEATING 47 UPPER, LOWER 22 & 1 WHEELCHAIR WITH 16 STANDEES OR 22 & 16.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 23,
+        "seatsUpperDeck": 47,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 16,
+        "statusCode": "archived",
+        "tachoExemptMrk": true,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 152,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6900,
+              "gbWeight": 6300,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 643,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 12000,
+              "gbWeight": 11500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "DARWIN/EAST LANCS",
+        "bodyModel": "VYKING MYLLENIUM",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "179202",
+        "brakes": {
+          "brakeCode": "179202",
+          "brakeCodeOriginal": "202",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2860,
+            "secondaryBrakeForceA": 4022,
+            "serviceBrakeForceA": 8044
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1955,
+            "secondaryBrakeForceB": 3055,
+            "serviceBrakeForceB": 6110
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle no separate secondary brake",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE N/WEST",
+        "coifDate": "2004-09-15",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-18T16:14:55.209Z",
+        "createdById": "70302477",
+        "createdByName": "Doe, John",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m2",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18900,
+        "grossGbWeight": 17800,
+        "grossKerbWeight": 12220,
+        "grossLadenWeight": 17875,
+        "manufactureYear": 2004,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "04121",
+          "microfilmSerialNumber": "0223"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "complete",
+        "regnDate": "2004-08-23",
+        "remarks": "DDA PSVA2 SCHEDULE 1 & 2. DRIVER ONLY AIR CONDITIONING. POWER RAMP AT EXIT & INTERLOCKED ENTRANCE DOORS. KNEEL SUSPENSION & INTERLOCKED.\\nSEATING 47 UPPER, LOWER 22 & 1 WHEELCHAIR WITH 16 STANDEES OR 22 & 16.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 23,
+        "seatsUpperDeck": 47,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 16,
+        "statusCode": "current",
+        "tachoExemptMrk": true,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Part-paid prohibition clearance (retest without certificate), Test Type ID = 22, Vehicle = PSV",
+    "systemNumber": "286066",
+    "vin": "YS4KC4X2B01818344",
+    "partialVin": "818344",
+    "primaryVrm": "H358DUF",
+    "secondaryVrms": ["FIL8471"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 152,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 390,
+              "tyreSize": "295/80-22.5"
+            },
+            "weights": {
+              "designWeight": 6500,
+              "gbWeight": 6500,
+              "kerbWeight": 4005,
+              "ladenWeight": 5804
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 147,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 390,
+              "tyreSize": "295/80-22.5"
+            },
+            "weights": {
+              "designWeight": 11000,
+              "gbWeight": 10500,
+              "kerbWeight": 7109,
+              "ladenWeight": 9660
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON",
+        "bodyModel": "PARAMOUNT",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "155222",
+        "brakes": {
+          "brakeCode": "155222",
+          "brakeCodeOriginal": "222",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2474,
+            "secondaryBrakeForceA": 3479,
+            "serviceBrakeForceA": 6959
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1778,
+            "secondaryBrakeForceB": 2778,
+            "serviceBrakeForceB": 5557
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle Secondary brake on axle 2",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "SCANIA",
+        "chassisModel": "KC",
+        "coifCertifierName": "J DOE T/S43",
+        "coifDate": "1990-10-12",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2015-01-14T09:53:34.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 17500,
+        "grossGbWeight": 17000,
+        "grossKerbWeight": 11114,
+        "grossLadenWeight": 15464,
+        "lastUpdatedAt": "2022-03-18T16:00:29.301Z",
+        "lastUpdatedById": "70302477",
+        "lastUpdatedByName": "Evans, Richard",
+        "manufactureYear": 1990,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": null,
+          "microfilmRollNumber": null,
+          "microfilmSerialNumber": null
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "1991-03-14",
+        "remarks": " ",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 53,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 4,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 152,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 390,
+              "tyreSize": "295/80-22.5"
+            },
+            "weights": {
+              "designWeight": 6500,
+              "gbWeight": 6500,
+              "kerbWeight": 4005,
+              "ladenWeight": 5804
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 147,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 390,
+              "tyreSize": "295/80-22.5"
+            },
+            "weights": {
+              "designWeight": 11000,
+              "gbWeight": 10500,
+              "kerbWeight": 7109,
+              "ladenWeight": 9660
+            }
+          }
+        ],
+        "bodyMake": "PLAXTON",
+        "bodyModel": "PARAMOUNT",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "155222",
+        "brakes": {
+          "brakeCode": "155222",
+          "brakeCodeOriginal": "222",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2474,
+            "secondaryBrakeForceA": 3479,
+            "serviceBrakeForceA": 6959
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1778,
+            "secondaryBrakeForceB": 2778,
+            "serviceBrakeForceB": 5557
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle Secondary brake on axle 2",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "SCANIA",
+        "chassisModel": "KC",
+        "coifCertifierName": "J DOE T/S43",
+        "coifDate": "1990-10-12",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-18T16:00:29.301Z",
+        "createdById": "70302477",
+        "createdByName": "Doe, John",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m3",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 17500,
+        "grossGbWeight": 17000,
+        "grossKerbWeight": 11114,
+        "grossLadenWeight": 15464,
+        "manufactureYear": 1990,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": null,
+          "microfilmRollNumber": null,
+          "microfilmSerialNumber": null
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "1991-03-14",
+        "remarks": " ",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 53,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 4,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Low Emissions Certificate (LEC) with annual test: PASS, Test Type ID = 39, Vehicle = PSV",
+    "systemNumber": "2644949",
+    "vin": "00000574",
+    "partialVin": "000574",
+    "primaryVrm": "YN51VHX",
+    "secondaryVrms": ["299844Z"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 140,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 312,
+              "tyreSize": "255/70-22.5"
+            },
+            "weights": {
+              "designWeight": 5500,
+              "gbWeight": 5500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 137,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 312,
+              "tyreSize": "255/70-22.5"
+            },
+            "weights": {
+              "designWeight": 9500,
+              "gbWeight": 9500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "OPTARE",
+        "bodyModel": "EXCEL",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "136222",
+        "brakes": {
+          "brakeCode": "136222",
+          "brakeCodeOriginal": "222",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2180,
+            "secondaryBrakeForceA": 3066,
+            "serviceBrakeForceA": 6131
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1442,
+            "secondaryBrakeForceB": 2252,
+            "serviceBrakeForceB": 4505
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle Secondary brake on axle 2",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "OPTARE",
+        "chassisModel": "EXCEL",
+        "coifCertifierName": "J DOE 29",
+        "coifDate": "2001-11-23",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2014-02-24T10:30:59.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 15000,
+        "grossGbWeight": 15000,
+        "grossKerbWeight": 9010,
+        "grossLadenWeight": 13625,
+        "lastUpdatedAt": "2022-03-11T13:04:45.874Z",
+        "lastUpdatedById": "70301545",
+        "lastUpdatedByName": "Charles, Daniel",
+        "manufactureYear": 2001,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "02023",
+          "microfilmSerialNumber": "0368"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "complete",
+        "regnDate": "0001-01-01",
+        "remarks": "DDA PSVA 2 SCHEDULE 1 AND 2.MAX G SPEED 55.37 SEATS AND 33 OR 40 AND 28 OR 37 AND 1 W/CHAIR AND 28 STANDEES.FOLDING RAMP AND KNEEL SUSP WITH INTERLOCK.ENG SOUND U/TRAY.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 37,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 33,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 140,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 312,
+              "tyreSize": "255/70-22.5"
+            },
+            "weights": {
+              "designWeight": 5500,
+              "gbWeight": 5500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 137,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "m",
+              "tyreCode": 312,
+              "tyreSize": "255/70-22.5"
+            },
+            "weights": {
+              "designWeight": 9500,
+              "gbWeight": 9500,
+              "kerbWeight": 0,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "OPTARE",
+        "bodyModel": "EXCEL",
+        "bodyType": {
+          "code": "s",
+          "description": "single decker"
+        },
+        "brakeCode": "136222",
+        "brakes": {
+          "brakeCode": "136222",
+          "brakeCodeOriginal": "222",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2180,
+            "secondaryBrakeForceA": 3066,
+            "serviceBrakeForceA": 6131
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1442,
+            "secondaryBrakeForceB": 2252,
+            "serviceBrakeForceB": 4505
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle Secondary brake on axle 2",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "OPTARE",
+        "chassisModel": "EXCEL",
+        "coifCertifierName": "J DOE 29",
+        "coifDate": "2001-11-23",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-11T13:04:45.874Z",
+        "createdById": "70301545",
+        "createdByName": "Doe, Johnathan",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m3",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 15000,
+        "grossGbWeight": 15000,
+        "grossKerbWeight": 9010,
+        "grossLadenWeight": 13625,
+        "manufactureYear": 2001,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "02023",
+          "microfilmSerialNumber": "0368"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "complete",
+        "regnDate": "0001-01-01",
+        "remarks": "DDA PSVA 2 SCHEDULE 1 AND 2.MAX G SPEED 55.37 SEATS AND 33 OR 40 AND 28 OR 37 AND 1 W/CHAIR AND 28 STANDEES.FOLDING RAMP AND KNEEL SUSP WITH INTERLOCK.ENG SOUND U/TRAY.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 37,
+        "seatsUpperDeck": 0,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 33,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
+  },
+  {
+    "vtmComment": "Low Emissions Certificate (LEC) with annual test: FAIL, Test Type ID = 39, Vehicle = PSV",
+    "systemNumber": "2597706",
+    "vin": "1A001481",
+    "partialVin": "001481",
+    "primaryVrm": "Y926OJL",
+    "secondaryVrms": ["Y926OTL"],
+    "techRecord": [
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6500,
+              "gbWeight": 6300,
+              "kerbWeight": 4170,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 11500,
+              "gbWeight": 11500,
+              "kerbWeight": 8070,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "DARWIN/EAST LANCS",
+        "bodyModel": "VYKING D/D",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "180222",
+        "brakes": {
+          "brakeCode": "180222",
+          "brakeCodeOriginal": "222",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2880,
+            "secondaryBrakeForceA": 4050,
+            "serviceBrakeForceA": 8100
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1958,
+            "secondaryBrakeForceB": 3060,
+            "serviceBrakeForceB": 6120
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle Secondary brake on axle 2",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE N/WEST",
+        "coifDate": "2001-06-21",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2013-06-13T09:10:01.000000Z",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18000,
+        "grossGbWeight": 17800,
+        "grossKerbWeight": 12240,
+        "grossLadenWeight": 18000,
+        "lastUpdatedAt": "2022-03-17T13:32:08.911Z",
+        "lastUpdatedById": "70300386",
+        "lastUpdatedByName": "Hopkins, Tracy",
+        "manufactureYear": 2001,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "01104",
+          "microfilmSerialNumber": "0393"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "0001-01-01",
+        "remarks": "MANUAL FOLD OUT W/CHAIR RAMP AT ENTRANCE DOOR INTERLOCKED TO GEARBOX.\\nENTRANCE DOOR OPERATION INTERLOCKED TO KNEELING SUSPENSION.\\nSEATING 47 UPPER, LOWER 30 & 17 OR 27 SEATS & 1 W/CHAIR WITH 17 STANDEES.\\nPSVA2 SCHEDULES 1 & 2.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 30,
+        "seatsUpperDeck": 47,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 17,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "updateType": "techRecordUpdate",
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      },
+      {
+        "approvalTypeNumber": null,
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 148,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 6500,
+              "gbWeight": 6300,
+              "kerbWeight": 4170,
+              "ladenWeight": 0
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 145,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "speedCategorySymbol": "j",
+              "tyreCode": 439,
+              "tyreSize": "275/70-22.5"
+            },
+            "weights": {
+              "designWeight": 11500,
+              "gbWeight": 11500,
+              "kerbWeight": 8070,
+              "ladenWeight": 0
+            }
+          }
+        ],
+        "bodyMake": "DARWIN/EAST LANCS",
+        "bodyModel": "VYKING D/D",
+        "bodyType": {
+          "code": "d",
+          "description": "double decker"
+        },
+        "brakeCode": "180222",
+        "brakes": {
+          "brakeCode": "180222",
+          "brakeCodeOriginal": "222",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2880,
+            "secondaryBrakeForceA": 4050,
+            "serviceBrakeForceA": 8100
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 1958,
+            "secondaryBrakeForceB": 3060,
+            "serviceBrakeForceB": 6120
+          },
+          "dataTrBrakeOne": "2 axles F/R split",
+          "dataTrBrakeThree": "2 or 3 axle Parking brake on axle 2",
+          "dataTrBrakeTwo": "2 or 3 axle Secondary brake on axle 2",
+          "retarderBrakeOne": "hydraulic",
+          "retarderBrakeTwo": "none"
+        },
+        "chassisMake": "VOLVO",
+        "chassisModel": "B7TL",
+        "coifCertifierName": "JOHN DOE N/WEST",
+        "coifDate": "2001-06-21",
+        "coifSerialNumber": "987654",
+        "conversionRefNo": " ",
+        "createdAt": "2022-03-17T13:32:08.911Z",
+        "createdById": "70300386",
+        "createdByName": "Doe, Jane",
+        "dda": {
+          "certificateIssued": false,
+          "ddaNotes": " "
+        },
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "height": 0,
+          "length": 0,
+          "width": 0
+        },
+        "dispensations": " ",
+        "euVehicleCategory": "m2",
+        "frontAxleToRearAxle": 0,
+        "fuelPropulsionSystem": "DieselPetrol",
+        "grossDesignWeight": 18000,
+        "grossGbWeight": 17800,
+        "grossKerbWeight": 12240,
+        "grossLadenWeight": 18000,
+        "manufactureYear": 2001,
+        "maxTrainGbWeight": 0,
+        "microfilm": {
+          "microfilmDocumentType": "COIF Productional",
+          "microfilmRollNumber": "01104",
+          "microfilmSerialNumber": "0393"
+        },
+        "modelLiteral": null,
+        "noOfAxles": 2,
+        "numberOfSeatbelts": null,
+        "numberOfWheelsDriven": 2,
+        "reasonForCreation": "COIF",
+        "recordCompleteness": "testable",
+        "regnDate": "0001-01-01",
+        "remarks": "MANUAL FOLD OUT W/CHAIR RAMP AT ENTRANCE DOOR INTERLOCKED TO GEARBOX.\\nENTRANCE DOOR OPERATION INTERLOCKED TO KNEELING SUSPENSION.\\nSEATING 47 UPPER, LOWER 30 & 17 OR 27 SEATS & 1 W/CHAIR WITH 17 STANDEES.\\nPSVA2 SCHEDULES 1 & 2.",
+        "seatbeltInstallationApprovalDate": null,
+        "seatsLowerDeck": 30,
+        "seatsUpperDeck": 47,
+        "speedLimiterMrk": false,
+        "speedRestriction": 0,
+        "standingCapacity": 17,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 0,
+        "unladenWeight": 0,
+        "variantNumber": null,
+        "variantVersionNumber": null,
+        "vehicleClass": {
+          "code": "l",
+          "description": "large psv(ie: greater than 23 seats)"
+        },
+        "vehicleConfiguration": "rigid",
+        "vehicleSize": "large",
+        "vehicleType": "psv"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Adds technical record data for development, testing and sign-off for PSV validation groups 1, 2, and 15

[CB2-4887](https://dvsa.atlassian.net/browse/CB2-4887)