### PR TITLE
feat(cb2-5702): fix the validation for hgv and trl dimension fields

### DIFF
--- a/src/utils/validations/HgvValidations.ts
+++ b/src/utils/validations/HgvValidations.ts
@@ -29,14 +29,14 @@ export const hgvValidation = commonSchema.keys({
   maxTrainDesignWeight: Joi.number().min(0).max(99999).optional().allow(null),
   tyreUseCode: Joi.string().max(2).optional().allow(null, ''),
   dimensions: Joi.object().keys({
-    length: Joi.number().min(0).max(99999).required(),
-    width: Joi.number().min(0).max(99999).required(),
+    length: Joi.number().min(0).max(99999).optional().allow(null),
+    width: Joi.number().min(0).max(99999).optional().allow(null),
     axleSpacing: Joi.array().items(Joi.object().keys({
       value: Joi.number().min(0).max(99999).optional().allow(null),
       axles: Joi.string().optional()
     })).optional()
   }).required(),
-  frontAxleToRearAxle: Joi.number().min(0).max(99999).required(),
+  frontAxleToRearAxle: Joi.number().min(0).max(99999).optional().allow(null),
   frontAxleTo5thWheelCouplingMin: Joi.number().min(0).max(99999).optional().allow(null),
   frontAxleTo5thWheelCouplingMax: Joi.number().min(0).max(99999).optional().allow(null),
   frontAxleTo5thWheelMin: Joi.number().min(0).max(99999).optional().allow(null),

--- a/src/utils/validations/TrlValidations.ts
+++ b/src/utils/validations/TrlValidations.ts
@@ -48,14 +48,14 @@ export const trlValidation = commonSchema.keys({
     antilockBrakingSystem: Joi.boolean().required()
   }).required(),
   dimensions: Joi.object().keys({
-    length: Joi.number().min(0).max(99999).required(),
-    width: Joi.number().min(0).max(99999).required(),
+    length: Joi.number().min(0).max(99999).optional().allow(null),
+    width: Joi.number().min(0).max(99999).optional().allow(null),
     axleSpacing: Joi.array().items(Joi.object().keys({
       value: Joi.number().min(0).max(99999).optional().allow(null),
       axles: Joi.string().optional()
     })).optional()
   }).required(),
-  frontAxleToRearAxle: Joi.number().min(0).max(99999).required(),
+  frontAxleToRearAxle: Joi.number().min(0).max(99999).optional().allow(null),
   rearAxleToRearTrl: Joi.number().min(0).max(99999).required(),
   couplingCenterToRearAxleMin: Joi.number().min(0).max(99999).required(),
   couplingCenterToRearAxleMax: Joi.number().min(0).max(99999).required(),


### PR DESCRIPTION
## Amend HGV & TRL Dimensions section

- Make `width`, `length` and `frontAxleToRearAxle` fields optional.

[CB2-5702](https://dvsa.atlassian.net/browse/CB2-5702)