### PR TITLE
feat(cb2-6902): handle vehicle with changed vin in get request response

### DIFF
--- a/@Types/TechRecords.d.ts
+++ b/@Types/TechRecords.d.ts
@@ -34,6 +34,7 @@ export interface Trailer extends TrailerIdentifer {
 }
 
 export interface TechRecord {
+  historicVin?: string;
   recordCompleteness: string;
   euVehicleCategory: string;
   vehicleType: string;

--- a/src/handlers/TechRecordsListHandler.ts
+++ b/src/handlers/TechRecordsListHandler.ts
@@ -31,7 +31,7 @@ export class TechRecordsListHandler<T extends Vehicle> {
         throw new HTTPError(404, HTTPRESPONSE.RESOURCE_NOT_FOUND);
       }
 
-      if (searchCriteria === SEARCHCRITERIA.SYSTEM_NUMBER && this.multipleRecordsWithSameSystemNumber(techRecordItems)) {
+      if (searchCriteria === SEARCHCRITERIA.SYSTEM_NUMBER && techRecordItems.length > 1) {
         techRecordItems = this.mergeRecordsWithSameSystemNumber(techRecordItems);
       }
 
@@ -143,11 +143,6 @@ export class TechRecordsListHandler<T extends Vehicle> {
     }
 
     return techRecordItem;
-  }
-
-  private multipleRecordsWithSameSystemNumber(techRecordItems: T[]): boolean {
-    const uniqueSystemNumbers = new Set(techRecordItems.map((item) => item.systemNumber));
-    return uniqueSystemNumbers.size !== techRecordItems.length;
   }
 
   private mergeRecordsWithSameSystemNumber(techRecordItems: T[]) {

--- a/src/handlers/TechRecordsListHandler.ts
+++ b/src/handlers/TechRecordsListHandler.ts
@@ -166,8 +166,8 @@ export class TechRecordsListHandler<T extends Vehicle> {
 
       const existingRecord = recordsToReturn[existingRecordIndex];
 
-      const existingRecordCreatedAt = Math.min(...existingRecord.techRecord.map((techRecordObject) => new Date(techRecordObject.createdAt).getTime()));
-      const itemCreatedAt =  Math.min(...vehicle.techRecord.map((techRecordObject) => new Date(techRecordObject.createdAt).getTime()));
+      const existingRecordCreatedAt = Math.max(...existingRecord.techRecord.map((techRecordObject) => new Date(techRecordObject.createdAt).getTime()));
+      const itemCreatedAt =  Math.max(...vehicle.techRecord.map((techRecordObject) => new Date(techRecordObject.createdAt).getTime()));
 
       if (itemCreatedAt < existingRecordCreatedAt) {
         return recordsToReturn[existingRecordIndex].techRecord.push(...vehicle.techRecord);

--- a/src/handlers/TechRecordsListHandler.ts
+++ b/src/handlers/TechRecordsListHandler.ts
@@ -27,6 +27,10 @@ export class TechRecordsListHandler<T extends Vehicle> {
         searchCriteria
       );
 
+      if (techRecordItems.length === 0) {
+        throw new HTTPError(404, HTTPRESPONSE.RESOURCE_NOT_FOUND);
+      }
+
       if (searchCriteria === SEARCHCRITERIA.SYSTEM_NUMBER && this.multipleRecordsWithSameSystemNumber(techRecordItems)) {
         techRecordItems = this.mergeRecordsWithSameSystemNumber(techRecordItems);
       }
@@ -95,7 +99,7 @@ export class TechRecordsListHandler<T extends Vehicle> {
 
   /* #region  Private functions */
   private filterTechRecordsByStatus(techRecordItems: T[], status: string): T[] {
-   return techRecordItems.map((item) => this.filterTechRecordsForIndividualVehicleByStatus(item, status));
+   return techRecordItems.map((item) => this.filterTechRecordsForIndividualVehicleByStatus(item, status)).filter((item) => item.techRecord.length > 0);
   }
 
   private filterTechRecordsForIndividualVehicleByStatus(
@@ -136,10 +140,6 @@ export class TechRecordsListHandler<T extends Vehicle> {
         originalTechRecordItem,
         STATUS.CURRENT
       );
-    }
-
-    if (techRecordItem.techRecord.length <= 0) {
-      throw new HTTPError(404, HTTPRESPONSE.RESOURCE_NOT_FOUND);
     }
 
     return techRecordItem;

--- a/src/handlers/TechRecordsListHandler.ts
+++ b/src/handlers/TechRecordsListHandler.ts
@@ -2,7 +2,7 @@ import TechRecordsDAO from "../models/TechRecordsDAO";
 import { ISearchCriteria } from "../../@Types/ISearchCriteria";
 import { HTTPRESPONSE, SEARCHCRITERIA, STATUS } from "../assets/Enums";
 import HTTPError from "../models/HTTPError";
-import { cloneDeep, union } from "lodash";
+import { cloneDeep } from "lodash";
 import { Vehicle } from "../../@Types/TechRecords";
 import { ErrorHandler } from "./ErrorHandler";
 

--- a/src/handlers/TechRecordsListHandler.ts
+++ b/src/handlers/TechRecordsListHandler.ts
@@ -153,24 +153,20 @@ export class TechRecordsListHandler<T extends Vehicle> {
         vehicle.techRecord[index].historicVin = vehicle.vin;
       });
 
-      const existingRecordIndex = recordsToReturn.findIndex((record) => record.systemNumber === vehicle.systemNumber);
-
-      if (existingRecordIndex === -1) {
+      if (!recordsToReturn[0]) {
         return recordsToReturn.push(vehicle);
       }
 
-      const existingRecord = recordsToReturn[existingRecordIndex];
-
-      const existingRecordCreatedAt = Math.max(...existingRecord.techRecord.map((techRecordObject) => new Date(techRecordObject.createdAt).getTime()));
+      const existingRecordCreatedAt = Math.max(...recordsToReturn[0].techRecord.map((techRecordObject) => new Date(techRecordObject.createdAt).getTime()));
       const itemCreatedAt =  Math.max(...vehicle.techRecord.map((techRecordObject) => new Date(techRecordObject.createdAt).getTime()));
 
       if (itemCreatedAt < existingRecordCreatedAt) {
-        return recordsToReturn[existingRecordIndex].techRecord.push(...vehicle.techRecord);
+        return recordsToReturn[0].techRecord.push(...vehicle.techRecord);
       }
 
-      const oldItems = cloneDeep(existingRecord);
-      recordsToReturn[existingRecordIndex] = cloneDeep(vehicle);
-      recordsToReturn[existingRecordIndex].techRecord.push(...oldItems.techRecord);
+      const oldItems = cloneDeep(recordsToReturn[0]);
+      recordsToReturn[0] = cloneDeep(vehicle);
+      recordsToReturn[0].techRecord.push(...oldItems.techRecord);
     });
 
     return recordsToReturn;

--- a/src/handlers/TechRecordsListHandler.ts
+++ b/src/handlers/TechRecordsListHandler.ts
@@ -171,7 +171,7 @@ export class TechRecordsListHandler<T extends Vehicle> {
         techRecordObject.historicVin = oldItems.vin;
       });
 
-      existingRecordWithSameSystemNumber = vehicle;
+      existingRecordWithSameSystemNumber = cloneDeep(vehicle);
       existingRecordWithSameSystemNumber.techRecord.push(...oldItems.techRecord);
     });
 

--- a/src/handlers/TechRecordsListHandler.ts
+++ b/src/handlers/TechRecordsListHandler.ts
@@ -146,30 +146,30 @@ export class TechRecordsListHandler<T extends Vehicle> {
   }
 
   private mergeRecordsWithSameSystemNumber(techRecordItems: T[]) {
-    const recordsToReturn: T[] = [];
+    let stitchedRecord = {} as T;
 
     techRecordItems.forEach((vehicle) => {
       vehicle.techRecord.forEach((object, index) => {
         vehicle.techRecord[index].historicVin = vehicle.vin;
       });
 
-      if (!recordsToReturn[0]) {
-        return recordsToReturn.push(vehicle);
+      if (!stitchedRecord.systemNumber) {
+        return stitchedRecord = vehicle;
       }
 
-      const existingRecordCreatedAt = Math.max(...recordsToReturn[0].techRecord.map((techRecordObject) => new Date(techRecordObject.createdAt).getTime()));
+      const stitchedRecordCreatedAt = Math.max(...stitchedRecord.techRecord.map((techRecordObject) => new Date(techRecordObject.createdAt).getTime()));
       const itemCreatedAt =  Math.max(...vehicle.techRecord.map((techRecordObject) => new Date(techRecordObject.createdAt).getTime()));
 
-      if (itemCreatedAt < existingRecordCreatedAt) {
-        return recordsToReturn[0].techRecord.push(...vehicle.techRecord);
+      if (itemCreatedAt < stitchedRecordCreatedAt) {
+        return stitchedRecord.techRecord.push(...vehicle.techRecord);
       }
 
-      const oldItems = cloneDeep(recordsToReturn[0]);
-      recordsToReturn[0] = cloneDeep(vehicle);
-      recordsToReturn[0].techRecord.push(...oldItems.techRecord);
+      const oldItems = cloneDeep(stitchedRecord);
+      stitchedRecord = cloneDeep(vehicle);
+      stitchedRecord.techRecord.push(...oldItems.techRecord);
     });
 
-    return recordsToReturn;
+    return [stitchedRecord];
   }
   /* #endregion */
 }

--- a/src/handlers/TechRecordsListHandler.ts
+++ b/src/handlers/TechRecordsListHandler.ts
@@ -154,9 +154,9 @@ export class TechRecordsListHandler<T extends Vehicle> {
     const recordsToReturn: T[] = [];
 
     techRecordItems.forEach((vehicle) => {
-      vehicle.techRecord.forEach((_object, index) => {
-        vehicle.techRecord[index].historicVin = vehicle.vin
-      })
+      vehicle.techRecord.forEach((object, index) => {
+        vehicle.techRecord[index].historicVin = vehicle.vin;
+      });
 
       const existingRecordIndex = recordsToReturn.findIndex((record) => record.systemNumber === vehicle.systemNumber);
 
@@ -164,11 +164,11 @@ export class TechRecordsListHandler<T extends Vehicle> {
         return recordsToReturn.push(vehicle);
       }
 
-      const existingRecord = recordsToReturn[existingRecordIndex]
+      const existingRecord = recordsToReturn[existingRecordIndex];
 
       const existingRecordCreatedAt = Math.min(...existingRecord.techRecord.map((techRecordObject) => new Date(techRecordObject.createdAt).getTime()));
       const itemCreatedAt =  Math.min(...vehicle.techRecord.map((techRecordObject) => new Date(techRecordObject.createdAt).getTime()));
-      
+
       if (itemCreatedAt < existingRecordCreatedAt) {
         return recordsToReturn[existingRecordIndex].techRecord.push(...vehicle.techRecord);
       }

--- a/src/models/TechRecordsDAO.ts
+++ b/src/models/TechRecordsDAO.ts
@@ -45,11 +45,11 @@ class TechRecordsDAO {
 
   private queryBuilder(searchTerm: string, searchCriteria: SEARCHCRITERIA, query: QueryInput) {
 
-    Object.assign(query.ExpressionAttributeNames ?? {}, {
+    Object.assign(query.ExpressionAttributeNames!, {
       [`#${searchCriteria}`]: searchCriteria === SEARCHCRITERIA.VRM ? "primaryVrm" : searchCriteria,
     });
 
-    Object.assign(query.ExpressionAttributeValues ?? {}, {
+    Object.assign(query.ExpressionAttributeValues!, {
       [`:${searchCriteria}`]: searchTerm,
     });
 

--- a/src/models/TechRecordsDAO.ts
+++ b/src/models/TechRecordsDAO.ts
@@ -44,17 +44,12 @@ class TechRecordsDAO {
   };
 
   private queryBuilder(searchTerm: string, searchCriteria: SEARCHCRITERIA, query: QueryInput) {
-    if (searchCriteria === SEARCHCRITERIA.VRM) {
-      Object.assign(query.ExpressionAttributeNames, {
-        [`#${searchCriteria}`]: "primaryVrm",
-      });
-    } else {
-      Object.assign(query.ExpressionAttributeNames, {
-        [`#${searchCriteria}`]: searchCriteria,
-      });
-    }
 
-    Object.assign(query.ExpressionAttributeValues, {
+    Object.assign(query.ExpressionAttributeNames ?? {}, {
+      [`#${searchCriteria}`]: searchCriteria === SEARCHCRITERIA.VRM ? "primaryVrm" : searchCriteria,
+    });
+
+    Object.assign(query.ExpressionAttributeValues ?? {}, {
       [`:${searchCriteria}`]: searchTerm,
     });
 

--- a/src/models/TechRecordsDAO.ts
+++ b/src/models/TechRecordsDAO.ts
@@ -35,6 +35,34 @@ class TechRecordsDAO {
     }
   }
 
+  private readonly CriteriaIndexMap: {[key: string]: string} = {
+    systemNumber: "SysNumIndex",
+    partialVin: "PartialVinIndex",
+    vrm: "VRMIndex",
+    vin: "VinIndex",
+    trailerId: "TrailerIdIndex"
+  };
+
+  private queryBuilder(searchTerm: string, searchCriteria: SEARCHCRITERIA, query: QueryInput) {
+    if (searchCriteria === SEARCHCRITERIA.VRM) {
+      Object.assign(query.ExpressionAttributeNames, {
+        [`#${searchCriteria}`]: "primaryVrm",
+      });
+    } else {
+      Object.assign(query.ExpressionAttributeNames, {
+        [`#${searchCriteria}`]: searchCriteria,
+      });
+    }
+
+    Object.assign(query.ExpressionAttributeValues, {
+      [`:${searchCriteria}`]: searchTerm,
+    });
+
+    query.KeyConditionExpression = `#${searchCriteria} = :${searchCriteria}`;
+
+    query.IndexName = this.CriteriaIndexMap[searchCriteria];
+  }
+
   public getBySearchTerm(searchTerm: string, searchCriteria: ISearchCriteria) {
     searchTerm = searchTerm.toUpperCase();
     const query: QueryInput = {
@@ -46,66 +74,17 @@ class TechRecordsDAO {
     };
 
     if (isSysNumSearch(searchCriteria)) {
-      // Query for a specific System Number
-      Object.assign(query.ExpressionAttributeValues, {
-        ":systemNumber": searchTerm,
-      });
-
-      Object.assign(query.ExpressionAttributeNames, {
-        "#systemNumber": "systemNumber",
-      });
-
-      query.IndexName = "SysNumIndex";
-      query.KeyConditionExpression = "#systemNumber = :systemNumber";
+      this.queryBuilder(searchTerm, SEARCHCRITERIA.SYSTEM_NUMBER, query);
     } else if (isVinSearch(searchTerm, searchCriteria)) {
-      // Query for a full VIN
-      Object.assign(query, { IndexName: "VinIndex" });
-      Object.assign(query.ExpressionAttributeValues, {
-        ":vin": searchTerm,
-      });
-
-      Object.assign(query.ExpressionAttributeNames, {
-        "#vin": "vin",
-      });
-
-      query.IndexName = "VinIndex";
-      query.KeyConditionExpression = "#vin = :vin";
+      this.queryBuilder(searchTerm, SEARCHCRITERIA.VIN, query);
     } else if (isTrailerSearch(searchTerm, searchCriteria)) {
-      // Query for a Trailer ID
-      Object.assign(query.ExpressionAttributeValues, {
-        ":trailerId": searchTerm,
-      });
-      Object.assign(query.ExpressionAttributeNames, {
-        "#trailerId": "trailerId",
-      });
-
-      query.IndexName = "TrailerIdIndex";
-      query.KeyConditionExpression = "#trailerId = :trailerId";
+      this.queryBuilder(searchTerm, SEARCHCRITERIA.TRAILERID, query);
     } else if (isPartialVinSearch(searchTerm, searchCriteria)) {
-      // Query for a partial VIN
-      Object.assign(query.ExpressionAttributeValues, {
-        ":partialVin": searchTerm,
-      });
-
-      Object.assign(query.ExpressionAttributeNames, {
-        "#partialVin": "partialVin",
-      });
-
-      query.IndexName = "PartialVinIndex";
-      query.KeyConditionExpression = "#partialVin = :partialVin";
+      this.queryBuilder(searchTerm, SEARCHCRITERIA.PARTIALVIN, query);
     } else if (isVrmSearch(searchTerm, searchCriteria)) {
-      // Query for a VRM
-      Object.assign(query.ExpressionAttributeValues, {
-        ":vrm": searchTerm,
-      });
-
-      Object.assign(query.ExpressionAttributeNames, {
-        "#vrm": "primaryVrm",
-      });
-
-      query.IndexName = "VRMIndex";
-      query.KeyConditionExpression = "#vrm = :vrm";
+      this.queryBuilder(searchTerm, SEARCHCRITERIA.VRM, query);
     }
+
     console.log("Query Params for getBySearchTerm ", query);
     try {
       return this.queryAllData(query);

--- a/tests/integration/techRecords.intTest.ts
+++ b/tests/integration/techRecords.intTest.ts
@@ -1,5 +1,6 @@
 /* global describe context it before beforeEach after afterEach */
 import supertest from "supertest";
+import stitchedRecords from "../resources/stitchedUpTechRecords.json";
 
 const url = "http://localhost:3005/";
 const request = supertest(url);
@@ -399,6 +400,29 @@ describe("techRecords", () => {
           expect(res.body[0].techRecord.length).toEqual(
             mockData[0].techRecord.length
           );
+        });
+      });
+    });
+
+    context("and when a search by system number is done", () => {
+      context("and no status code is provided", () => {
+        context("and there are multiple dynamodb records for that system number", () => {
+          it("should return a stitched up record for that system number with the most recent vin at the base of the tech record", async () => {
+            const res = await request.get(
+              "vehicles/11220280/tech-records?status=all&searchCriteria=systemNumber"
+            );
+            console.log(res.body);
+            expect(res.status).toEqual(200);
+            expect(res.header["access-control-allow-origin"]).toEqual("*");
+            expect(res.header["access-control-allow-credentials"]).toEqual(
+              "true"
+            );
+            expect(res.body.length).toEqual(1);
+            expect(res.body).toEqual([stitchedRecords]);
+            expect(res.body[0].techRecord.length).toEqual(
+              4
+            );
+          });
         });
       });
     });

--- a/tests/resources/stitchedUpTechRecords.json
+++ b/tests/resources/stitchedUpTechRecords.json
@@ -1,0 +1,532 @@
+{
+    "systemNumber": "11220280",
+    "techRecord": [
+      {
+        "alterationMarker": false,
+        "applicantDetails": {
+          "address1": "applicant address 1",
+          "address2": "applicant address 2",
+          "address3": "applicant address 3",
+          "emailAddress": "test@test.com",
+          "name": "applicant name",
+          "postCode": "PO16 7GZ",
+          "postTown": "applicant post town",
+          "telephoneNumber": "123456"
+        },
+        "approvalType": "NTA",
+        "approvalTypeNumber": "1234",
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 2,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "tyreCode": 462,
+              "tyreSize": "12-22.5"
+            },
+            "weights": {
+              "designWeight": 7500,
+              "eecWeight": 7600,
+              "gbWeight": 7700
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 2,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "tyreCode": 462,
+              "tyreSize": "12-22.5"
+            },
+            "weights": {
+              "designWeight": 13000,
+              "eecWeight": 10000,
+              "gbWeight": 9500
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "o",
+          "description": "other"
+        },
+        "brakes": {
+          "dtpNumber": "3798A"
+        },
+        "conversionRefNo": " ",
+        "createdAt": "2020-07-28T00:06:25.249Z",
+        "createdById": "12345",
+        "createdByName": "sean",
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "axleSpacing": [
+            {
+              "axles": "1-2",
+              "value": 11000
+            }
+          ],
+          "length": 10000,
+          "width": 2000
+        },
+        "drawbarCouplingFitted": false,
+        "emissionsLimit": 20,
+        "euroStandard": "2",
+        "euVehicleCategory": "n2",
+        "frontAxleTo5thWheelCouplingMax": 1300,
+        "frontAxleTo5thWheelCouplingMin": 1400,
+        "frontAxleTo5thWheelMax": 1100,
+        "frontAxleTo5thWheelMin": 1200,
+        "frontAxleToRearAxle": 1000,
+        "fuelPropulsionSystem": "Electric",
+        "functionCode": "A",
+        "grossDesignWeight": 33500,
+        "grossEecWeight": 26000,
+        "grossGbWeight": 25000,
+        "make": "VOLVO",
+        "manufactureYear": 1984,
+        "maxTrainDesignWeight": 2800,
+        "maxTrainEecWeight": 2500,
+        "maxTrainGbWeight": 44000,
+        "microfilm": {
+          "microfilmDocumentType": "HGV COC + Int Plate",
+          "microfilmRollNumber": "12346",
+          "microfilmSerialNumber": "1234"
+        },
+        "model": "F12-33",
+        "noOfAxles": 3,
+        "notes": " ",
+        "ntaNumber": "0000514903",
+        "numberOfWheelsDriven": 4,
+        "offRoad": false,
+        "plates": [
+          {
+            "plateIssueDate": "2100-12-31",
+            "plateIssuer": "issuer",
+            "plateReasonForIssue": "Replacement",
+            "plateSerialNumber": "123456"
+          }
+        ],
+        "reasonForCreation": "something",
+        "recordCompleteness": "complete",
+        "regnDate": "1985-01-01",
+        "roadFriendly": false,
+        "speedLimiterMrk": false,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 59500,
+        "trainEecWeight": 25000,
+        "trainGbWeight": 41000,
+        "tyreUseCode": "2B",
+        "variantNumber": "324324",
+        "variantVersionNumber": "345",
+        "vehicleClass": {
+          "code": "v",
+          "description": "heavy goods vehicle"
+        },
+        "vehicleConfiguration": "articulated",
+        "vehicleType": "hgv",
+        "historicVin": "H12220223"
+      },
+      {
+        "alterationMarker": false,
+        "applicantDetails": {
+          "address1": "applicant address 1",
+          "address2": "applicant address 2",
+          "address3": "applicant address 3",
+          "emailAddress": "test@test.com",
+          "name": "applicant name",
+          "postCode": "PO16 7GZ",
+          "postTown": "applicant post town",
+          "telephoneNumber": "123456"
+        },
+        "approvalType": "NTA",
+        "approvalTypeNumber": "1234",
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 2,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "tyreCode": 462,
+              "tyreSize": "12-22.5"
+            },
+            "weights": {
+              "designWeight": 7500,
+              "eecWeight": 7600,
+              "gbWeight": 7700
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 2,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "tyreCode": 462,
+              "tyreSize": "12-22.5"
+            },
+            "weights": {
+              "designWeight": 13000,
+              "eecWeight": 10000,
+              "gbWeight": 9500
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "o",
+          "description": "other"
+        },
+        "brakes": {
+          "dtpNumber": "3798A"
+        },
+        "conversionRefNo": " ",
+        "createdAt": "2019-07-28T00:06:25.249Z",
+        "createdById": "12345",
+        "createdByName": "sean",
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "axleSpacing": [
+            {
+              "axles": "1-2",
+              "value": 11000
+            }
+          ],
+          "length": 10000,
+          "width": 2000
+        },
+        "drawbarCouplingFitted": false,
+        "emissionsLimit": 20,
+        "euroStandard": "2",
+        "euVehicleCategory": "n2",
+        "frontAxleTo5thWheelCouplingMax": 1300,
+        "frontAxleTo5thWheelCouplingMin": 1400,
+        "frontAxleTo5thWheelMax": 1100,
+        "frontAxleTo5thWheelMin": 1200,
+        "frontAxleToRearAxle": 1000,
+        "fuelPropulsionSystem": "Electric",
+        "functionCode": "A",
+        "grossDesignWeight": 33500,
+        "grossEecWeight": 26000,
+        "grossGbWeight": 25000,
+        "make": "VOLVO",
+        "manufactureYear": 1984,
+        "maxTrainDesignWeight": 2800,
+        "maxTrainEecWeight": 2500,
+        "maxTrainGbWeight": 44000,
+        "microfilm": {
+          "microfilmDocumentType": "HGV COC + Int Plate",
+          "microfilmRollNumber": "12346",
+          "microfilmSerialNumber": "1234"
+        },
+        "model": "F12-33",
+        "noOfAxles": 3,
+        "notes": " ",
+        "ntaNumber": "0000514903",
+        "numberOfWheelsDriven": 4,
+        "offRoad": false,
+        "plates": [
+          {
+            "plateIssueDate": "2100-12-31",
+            "plateIssuer": "issuer",
+            "plateReasonForIssue": "Replacement",
+            "plateSerialNumber": "123456"
+          }
+        ],
+        "reasonForCreation": "something",
+        "recordCompleteness": "complete",
+        "regnDate": "1985-01-01",
+        "roadFriendly": false,
+        "speedLimiterMrk": false,
+        "statusCode": "current",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 59500,
+        "trainEecWeight": 25000,
+        "trainGbWeight": 41000,
+        "tyreUseCode": "2B",
+        "variantNumber": "324324",
+        "variantVersionNumber": "345",
+        "vehicleClass": {
+          "code": "v",
+          "description": "heavy goods vehicle"
+        },
+        "vehicleConfiguration": "articulated",
+        "vehicleType": "hgv",
+        "historicVin": "H12220226"
+      },
+      {
+        "alterationMarker": false,
+        "applicantDetails": {
+          "address1": "applicant address 1",
+          "address2": "applicant address 2",
+          "address3": "applicant address 3",
+          "emailAddress": "test@test.com",
+          "name": "applicant name",
+          "postCode": "PO16 7GZ",
+          "postTown": "applicant post town",
+          "telephoneNumber": "123456"
+        },
+        "approvalType": "NTA",
+        "approvalTypeNumber": "1234",
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 2,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "tyreCode": 462,
+              "tyreSize": "12-22.5"
+            },
+            "weights": {
+              "designWeight": 7500,
+              "eecWeight": 7600,
+              "gbWeight": 7700
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 2,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "tyreCode": 462,
+              "tyreSize": "12-22.5"
+            },
+            "weights": {
+              "designWeight": 13000,
+              "eecWeight": 10000,
+              "gbWeight": 9500
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "o",
+          "description": "other"
+        },
+        "brakes": {
+          "dtpNumber": "3798A"
+        },
+        "conversionRefNo": " ",
+        "createdAt": "2018-07-28T00:06:25.249Z",
+        "createdById": "12345",
+        "createdByName": "sean",
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "axleSpacing": [
+            {
+              "axles": "1-2",
+              "value": 11000
+            }
+          ],
+          "length": 10000,
+          "width": 2000
+        },
+        "drawbarCouplingFitted": false,
+        "emissionsLimit": 20,
+        "euroStandard": "2",
+        "euVehicleCategory": "n2",
+        "frontAxleTo5thWheelCouplingMax": 1300,
+        "frontAxleTo5thWheelCouplingMin": 1400,
+        "frontAxleTo5thWheelMax": 1100,
+        "frontAxleTo5thWheelMin": 1200,
+        "frontAxleToRearAxle": 1000,
+        "fuelPropulsionSystem": "Electric",
+        "functionCode": "A",
+        "grossDesignWeight": 33500,
+        "grossEecWeight": 26000,
+        "grossGbWeight": 25000,
+        "make": "VOLVO",
+        "manufactureYear": 1984,
+        "maxTrainDesignWeight": 2800,
+        "maxTrainEecWeight": 2500,
+        "maxTrainGbWeight": 44000,
+        "microfilm": {
+          "microfilmDocumentType": "HGV COC + Int Plate",
+          "microfilmRollNumber": "12346",
+          "microfilmSerialNumber": "1234"
+        },
+        "model": "F12-33",
+        "noOfAxles": 3,
+        "notes": " ",
+        "ntaNumber": "0000514903",
+        "numberOfWheelsDriven": 4,
+        "offRoad": false,
+        "plates": [
+          {
+            "plateIssueDate": "2100-12-31",
+            "plateIssuer": "issuer",
+            "plateReasonForIssue": "Replacement",
+            "plateSerialNumber": "123456"
+          }
+        ],
+        "reasonForCreation": "something",
+        "recordCompleteness": "complete",
+        "regnDate": "1985-01-01",
+        "roadFriendly": false,
+        "speedLimiterMrk": false,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 59500,
+        "trainEecWeight": 25000,
+        "trainGbWeight": 41000,
+        "tyreUseCode": "2B",
+        "variantNumber": "324324",
+        "variantVersionNumber": "345",
+        "vehicleClass": {
+          "code": "v",
+          "description": "heavy goods vehicle"
+        },
+        "vehicleConfiguration": "articulated",
+        "vehicleType": "hgv",
+        "historicVin": "H12220225"
+      },
+      {
+        "alterationMarker": false,
+        "applicantDetails": {
+          "address1": "applicant address 1",
+          "address2": "applicant address 2",
+          "address3": "applicant address 3",
+          "emailAddress": "test@test.com",
+          "name": "applicant name",
+          "postCode": "PO16 7GZ",
+          "postTown": "applicant post town",
+          "telephoneNumber": "123456"
+        },
+        "approvalType": "NTA",
+        "approvalTypeNumber": "1234",
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 2,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "tyreCode": 462,
+              "tyreSize": "12-22.5"
+            },
+            "weights": {
+              "designWeight": 7500,
+              "eecWeight": 7600,
+              "gbWeight": 7700
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 2,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "tyreCode": 462,
+              "tyreSize": "12-22.5"
+            },
+            "weights": {
+              "designWeight": 13000,
+              "eecWeight": 10000,
+              "gbWeight": 9500
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "o",
+          "description": "other"
+        },
+        "brakes": {
+          "dtpNumber": "3798A"
+        },
+        "conversionRefNo": " ",
+        "createdAt": "2017-07-28T00:06:25.249Z",
+        "createdById": "12345",
+        "createdByName": "sean",
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "axleSpacing": [
+            {
+              "axles": "1-2",
+              "value": 11000
+            }
+          ],
+          "length": 10000,
+          "width": 2000
+        },
+        "drawbarCouplingFitted": false,
+        "emissionsLimit": 20,
+        "euroStandard": "2",
+        "euVehicleCategory": "n2",
+        "frontAxleTo5thWheelCouplingMax": 1300,
+        "frontAxleTo5thWheelCouplingMin": 1400,
+        "frontAxleTo5thWheelMax": 1100,
+        "frontAxleTo5thWheelMin": 1200,
+        "frontAxleToRearAxle": 1000,
+        "fuelPropulsionSystem": "Electric",
+        "functionCode": "A",
+        "grossDesignWeight": 33500,
+        "grossEecWeight": 26000,
+        "grossGbWeight": 25000,
+        "make": "VOLVO",
+        "manufactureYear": 1984,
+        "maxTrainDesignWeight": 2800,
+        "maxTrainEecWeight": 2500,
+        "maxTrainGbWeight": 44000,
+        "microfilm": {
+          "microfilmDocumentType": "HGV COC + Int Plate",
+          "microfilmRollNumber": "12346",
+          "microfilmSerialNumber": "1234"
+        },
+        "model": "F12-33",
+        "noOfAxles": 3,
+        "notes": " ",
+        "ntaNumber": "0000514903",
+        "numberOfWheelsDriven": 4,
+        "offRoad": false,
+        "plates": [
+          {
+            "plateIssueDate": "2100-12-31",
+            "plateIssuer": "issuer",
+            "plateReasonForIssue": "Replacement",
+            "plateSerialNumber": "123456"
+          }
+        ],
+        "reasonForCreation": "something",
+        "recordCompleteness": "complete",
+        "regnDate": "1985-01-01",
+        "roadFriendly": false,
+        "speedLimiterMrk": false,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 59500,
+        "trainEecWeight": 25000,
+        "trainGbWeight": 41000,
+        "tyreUseCode": "2B",
+        "variantNumber": "324324",
+        "variantVersionNumber": "345",
+        "vehicleClass": {
+          "code": "v",
+          "description": "heavy goods vehicle"
+        },
+        "vehicleConfiguration": "articulated",
+        "vehicleType": "hgv",
+        "historicVin": "H12220224"
+      }
+    ],
+    "vin": "H12220223",
+    "vrms": [
+        {
+            "isPrimary": true,
+            "vrm": "B999XFX"
+        },
+        {
+            "isPrimary": false,
+            "vrm": "DB999XFX"
+        }
+    ]
+  }

--- a/tests/resources/stitchedUpTechRecords.json
+++ b/tests/resources/stitchedUpTechRecords.json
@@ -57,135 +57,6 @@
           "dtpNumber": "3798A"
         },
         "conversionRefNo": " ",
-        "createdAt": "2020-07-28T00:06:25.249Z",
-        "createdById": "12345",
-        "createdByName": "sean",
-        "departmentalVehicleMarker": false,
-        "dimensions": {
-          "axleSpacing": [
-            {
-              "axles": "1-2",
-              "value": 11000
-            }
-          ],
-          "length": 10000,
-          "width": 2000
-        },
-        "drawbarCouplingFitted": false,
-        "emissionsLimit": 20,
-        "euroStandard": "2",
-        "euVehicleCategory": "n2",
-        "frontAxleTo5thWheelCouplingMax": 1300,
-        "frontAxleTo5thWheelCouplingMin": 1400,
-        "frontAxleTo5thWheelMax": 1100,
-        "frontAxleTo5thWheelMin": 1200,
-        "frontAxleToRearAxle": 1000,
-        "fuelPropulsionSystem": "Electric",
-        "functionCode": "A",
-        "grossDesignWeight": 33500,
-        "grossEecWeight": 26000,
-        "grossGbWeight": 25000,
-        "make": "VOLVO",
-        "manufactureYear": 1984,
-        "maxTrainDesignWeight": 2800,
-        "maxTrainEecWeight": 2500,
-        "maxTrainGbWeight": 44000,
-        "microfilm": {
-          "microfilmDocumentType": "HGV COC + Int Plate",
-          "microfilmRollNumber": "12346",
-          "microfilmSerialNumber": "1234"
-        },
-        "model": "F12-33",
-        "noOfAxles": 3,
-        "notes": " ",
-        "ntaNumber": "0000514903",
-        "numberOfWheelsDriven": 4,
-        "offRoad": false,
-        "plates": [
-          {
-            "plateIssueDate": "2100-12-31",
-            "plateIssuer": "issuer",
-            "plateReasonForIssue": "Replacement",
-            "plateSerialNumber": "123456"
-          }
-        ],
-        "reasonForCreation": "something",
-        "recordCompleteness": "complete",
-        "regnDate": "1985-01-01",
-        "roadFriendly": false,
-        "speedLimiterMrk": false,
-        "statusCode": "archived",
-        "tachoExemptMrk": false,
-        "trainDesignWeight": 59500,
-        "trainEecWeight": 25000,
-        "trainGbWeight": 41000,
-        "tyreUseCode": "2B",
-        "variantNumber": "324324",
-        "variantVersionNumber": "345",
-        "vehicleClass": {
-          "code": "v",
-          "description": "heavy goods vehicle"
-        },
-        "vehicleConfiguration": "articulated",
-        "vehicleType": "hgv",
-        "historicVin": "H12220223"
-      },
-      {
-        "alterationMarker": false,
-        "applicantDetails": {
-          "address1": "applicant address 1",
-          "address2": "applicant address 2",
-          "address3": "applicant address 3",
-          "emailAddress": "test@test.com",
-          "name": "applicant name",
-          "postCode": "PO16 7GZ",
-          "postTown": "applicant post town",
-          "telephoneNumber": "123456"
-        },
-        "approvalType": "NTA",
-        "approvalTypeNumber": "1234",
-        "axles": [
-          {
-            "axleNumber": 1,
-            "parkingBrakeMrk": false,
-            "tyres": {
-              "dataTrAxles": 2,
-              "fitmentCode": "single",
-              "plyRating": " ",
-              "tyreCode": 462,
-              "tyreSize": "12-22.5"
-            },
-            "weights": {
-              "designWeight": 7500,
-              "eecWeight": 7600,
-              "gbWeight": 7700
-            }
-          },
-          {
-            "axleNumber": 2,
-            "parkingBrakeMrk": false,
-            "tyres": {
-              "dataTrAxles": 2,
-              "fitmentCode": "double",
-              "plyRating": " ",
-              "tyreCode": 462,
-              "tyreSize": "12-22.5"
-            },
-            "weights": {
-              "designWeight": 13000,
-              "eecWeight": 10000,
-              "gbWeight": 9500
-            }
-          }
-        ],
-        "bodyType": {
-          "code": "o",
-          "description": "other"
-        },
-        "brakes": {
-          "dtpNumber": "3798A"
-        },
-        "conversionRefNo": " ",
         "createdAt": "2022-07-28T00:06:25.249Z",
         "createdById": "12345",
         "createdByName": "sean",
@@ -444,6 +315,135 @@
           "dtpNumber": "3798A"
         },
         "conversionRefNo": " ",
+        "createdAt": "2020-07-28T00:06:25.249Z",
+        "createdById": "12345",
+        "createdByName": "sean",
+        "departmentalVehicleMarker": false,
+        "dimensions": {
+          "axleSpacing": [
+            {
+              "axles": "1-2",
+              "value": 11000
+            }
+          ],
+          "length": 10000,
+          "width": 2000
+        },
+        "drawbarCouplingFitted": false,
+        "emissionsLimit": 20,
+        "euroStandard": "2",
+        "euVehicleCategory": "n2",
+        "frontAxleTo5thWheelCouplingMax": 1300,
+        "frontAxleTo5thWheelCouplingMin": 1400,
+        "frontAxleTo5thWheelMax": 1100,
+        "frontAxleTo5thWheelMin": 1200,
+        "frontAxleToRearAxle": 1000,
+        "fuelPropulsionSystem": "Electric",
+        "functionCode": "A",
+        "grossDesignWeight": 33500,
+        "grossEecWeight": 26000,
+        "grossGbWeight": 25000,
+        "make": "VOLVO",
+        "manufactureYear": 1984,
+        "maxTrainDesignWeight": 2800,
+        "maxTrainEecWeight": 2500,
+        "maxTrainGbWeight": 44000,
+        "microfilm": {
+          "microfilmDocumentType": "HGV COC + Int Plate",
+          "microfilmRollNumber": "12346",
+          "microfilmSerialNumber": "1234"
+        },
+        "model": "F12-33",
+        "noOfAxles": 3,
+        "notes": " ",
+        "ntaNumber": "0000514903",
+        "numberOfWheelsDriven": 4,
+        "offRoad": false,
+        "plates": [
+          {
+            "plateIssueDate": "2100-12-31",
+            "plateIssuer": "issuer",
+            "plateReasonForIssue": "Replacement",
+            "plateSerialNumber": "123456"
+          }
+        ],
+        "reasonForCreation": "something",
+        "recordCompleteness": "complete",
+        "regnDate": "1985-01-01",
+        "roadFriendly": false,
+        "speedLimiterMrk": false,
+        "statusCode": "archived",
+        "tachoExemptMrk": false,
+        "trainDesignWeight": 59500,
+        "trainEecWeight": 25000,
+        "trainGbWeight": 41000,
+        "tyreUseCode": "2B",
+        "variantNumber": "324324",
+        "variantVersionNumber": "345",
+        "vehicleClass": {
+          "code": "v",
+          "description": "heavy goods vehicle"
+        },
+        "vehicleConfiguration": "articulated",
+        "vehicleType": "hgv",
+        "historicVin": "H12220223"
+      },
+      {
+        "alterationMarker": false,
+        "applicantDetails": {
+          "address1": "applicant address 1",
+          "address2": "applicant address 2",
+          "address3": "applicant address 3",
+          "emailAddress": "test@test.com",
+          "name": "applicant name",
+          "postCode": "PO16 7GZ",
+          "postTown": "applicant post town",
+          "telephoneNumber": "123456"
+        },
+        "approvalType": "NTA",
+        "approvalTypeNumber": "1234",
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 2,
+              "fitmentCode": "single",
+              "plyRating": " ",
+              "tyreCode": 462,
+              "tyreSize": "12-22.5"
+            },
+            "weights": {
+              "designWeight": 7500,
+              "eecWeight": 7600,
+              "gbWeight": 7700
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": 2,
+              "fitmentCode": "double",
+              "plyRating": " ",
+              "tyreCode": 462,
+              "tyreSize": "12-22.5"
+            },
+            "weights": {
+              "designWeight": 13000,
+              "eecWeight": 10000,
+              "gbWeight": 9500
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "o",
+          "description": "other"
+        },
+        "brakes": {
+          "dtpNumber": "3798A"
+        },
+        "conversionRefNo": " ",
         "createdAt": "2017-07-28T00:06:25.249Z",
         "createdById": "12345",
         "createdByName": "sean",
@@ -518,7 +518,7 @@
         "historicVin": "H12220224"
       }
     ],
-    "vin": "H12220223",
+    "vin": "H12220226",
     "vrms": [
         {
             "isPrimary": true,

--- a/tests/resources/stitchedUpTechRecords.json
+++ b/tests/resources/stitchedUpTechRecords.json
@@ -186,7 +186,7 @@
           "dtpNumber": "3798A"
         },
         "conversionRefNo": " ",
-        "createdAt": "2019-07-28T00:06:25.249Z",
+        "createdAt": "2022-07-28T00:06:25.249Z",
         "createdById": "12345",
         "createdByName": "sean",
         "departmentalVehicleMarker": false,

--- a/tests/resources/technical-records.json
+++ b/tests/resources/technical-records.json
@@ -34986,7 +34986,7 @@
           "dtpNumber": "3798A"
         },
         "conversionRefNo": " ",
-        "createdAt": "2019-07-28T00:06:25.249Z",
+        "createdAt": "2022-07-28T00:06:25.249Z",
         "createdById": "12345",
         "createdByName": "sean",
         "departmentalVehicleMarker": false,

--- a/tests/resources/technical-records.json
+++ b/tests/resources/technical-records.json
@@ -26127,8 +26127,7 @@
           "description": "heavy goods vehicle"
         },
         "vehicleConfiguration": "articulated",
-        "vehicleType": "hgv",
-        "vin": "H12220223"
+        "vehicleType": "hgv"
       }
     ],
     "vin": "H12220223"
@@ -34713,7 +34712,7 @@
           "dtpNumber": "3798A"
         },
         "conversionRefNo": " ",
-        "createdAt": "2020-07-28T00:06:25.249Z",
+        "createdAt": "2017-07-28T00:06:25.249Z",
         "createdById": "12345",
         "createdByName": "sean",
         "departmentalVehicleMarker": false,
@@ -34783,8 +34782,7 @@
           "description": "heavy goods vehicle"
         },
         "vehicleConfiguration": "articulated",
-        "vehicleType": "hgv",
-        "vin": "H12220224"
+        "vehicleType": "hgv"
       }
     ],
     "vin": "H12220224"
@@ -34851,7 +34849,7 @@
           "dtpNumber": "3798A"
         },
         "conversionRefNo": " ",
-        "createdAt": "2020-07-28T00:06:25.249Z",
+        "createdAt": "2018-07-28T00:06:25.249Z",
         "createdById": "12345",
         "createdByName": "sean",
         "departmentalVehicleMarker": false,
@@ -34921,8 +34919,7 @@
           "description": "heavy goods vehicle"
         },
         "vehicleConfiguration": "articulated",
-        "vehicleType": "hgv",
-        "vin": "H12220225"
+        "vehicleType": "hgv"
       }
     ],
     "vin": "H12220225"
@@ -34989,7 +34986,7 @@
           "dtpNumber": "3798A"
         },
         "conversionRefNo": " ",
-        "createdAt": "2020-07-28T00:06:25.249Z",
+        "createdAt": "2019-07-28T00:06:25.249Z",
         "createdById": "12345",
         "createdByName": "sean",
         "departmentalVehicleMarker": false,
@@ -35059,8 +35056,7 @@
           "description": "heavy goods vehicle"
         },
         "vehicleConfiguration": "articulated",
-        "vehicleType": "hgv",
-        "vin": "H12220226"
+        "vehicleType": "hgv"
       }
     ],
     "vin": "H12220226"


### PR DESCRIPTION
## Ticket title

When a GET request is made to query the DynamoDB based on systemNumber, the API will now stitch together any DynamoDB records which have the same `systemNumber` but different `vin`. 

The stitching process involves pushing the objects from the `techRecord` array of the DynamoDB record with the **old** `vin` into the techRecord array of the DynamoDB record with the **newest** `vin`. 

The `vin` of a `techRecord` object at it's point in history is retained by adding a new `historicVin` attribute to each `techRecord` object.

The vehicle identifier attributes at the base of the returned record are the vehicle's **_current_** identifiers.

Other changes:
- Refactoring of the Dynamo query method
- Amending new seed data to be more realistic (have chronological `createdAt` dates)
- Fix bug where if you were searching on a vehicle identifier (e.g. `partialVin`) and a status (e.g. `archived`) and you returned multiple vehicles where one of the vehicle records did not have a record of that status, the API would prematurely throw an error due to the record that did not have that status instead of returning the record that met the search criteria.

[link to ticket number](https://dvsa.atlassian.net/browse/CB2-6902)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
