### PR TITLE
fix(cb2-6735): failing integration tests don't return non-zero exit code

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,35 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: PR-checks
+
+on:
+  push:
+    branches: ['develop', 'feature/VTMDEV-1']
+  pull_request:
+    branches: ['develop', 'feature/VTMDEV-1']
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Setup local dynamo
+        run: npm run tools-setup
+      - name: Build and test
+        run: npm run prepush
+      - name: Run linter
+        run: npm run lint

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -31,5 +31,8 @@ jobs:
         run: npm run tools-setup
       - name: Build and test
         run: npm run prepush
+        env:
+          AWS_ACCESS_KEY_ID: foo
+          AWS_SECRET_ACCESS_KEY: bar
       - name: Run linter
         run: npm run lint

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -17,17 +17,19 @@ const setupServer = (process: any) => {
     });
 
     process.stderr.setEncoding("utf-8").on("data", (stream: any) => {
-      console.log(stream);
       if (stream.includes(DYNAMO_LOCAL_ERROR_THREAD)) {
         throw new Error("Internal Java process crashed");
       }
       reject(stream);
     });
 
-    process.on("exit", (code: any, signal: any) =>
-      console.info(
-        `process terminated with code: ${code} and signal: ${signal}`
-      )
+    process.on("exit", (code: any, signal: any) => {
+      if (code !== 137) {
+        console.info(
+          `process terminated with code: ${code} and signal: ${signal}`
+        )
+      }
+    }
     );
   });
 };

--- a/scripts/teardown.ts
+++ b/scripts/teardown.ts
@@ -12,7 +12,6 @@ module.exports = async () => {
   try {
     await killTestSetup();
     console.log("processes killed");
-    process.exit(0);
   } catch (e) {
     console.log("Can not kill processes");
     console.error(e);

--- a/tests/integration/TechRecordsFunction.intTest.ts
+++ b/tests/integration/TechRecordsFunction.intTest.ts
@@ -1,5 +1,5 @@
 import LambdaTester from "lambda-tester";
-import {getTechRecords, getTechRecords as GetTechRecordsFunction} from "../../src/functions/getTechRecords";
+import { getTechRecords, getTechRecords as GetTechRecordsFunction } from "../../src/functions/getTechRecords";
 import { emptyDatabase, populateDatabase } from "../util/dbOperations";
 import { updateTechRecords as UpdateTechRecordsFunction } from "../../src/functions/updateTechRecords";
 import { postTechRecords as PostTechRecordsFunction } from "../../src/functions/postTechRecords";
@@ -43,7 +43,7 @@ describe("getTechRecords", () => {
           expect(result.statusCode).toEqual(400);
           // Path checking now handled in the handler. Now only checking for Path Params
           expect(result.body).toEqual(
-              JSON.stringify(HTTPRESPONSE.MISSING_PARAMETERS)
+            JSON.stringify(HTTPRESPONSE.MISSING_PARAMETERS)
           );
         });
     });
@@ -60,7 +60,7 @@ describe("getTechRecords", () => {
           expect(result.statusCode).toEqual(400);
           // Path checking now handled in the handler. Now only checking for Path Params
           expect(result.body).toEqual(
-              JSON.stringify(HTTPRESPONSE.MISSING_PARAMETERS)
+            JSON.stringify(HTTPRESPONSE.MISSING_PARAMETERS)
           );
         });
     });


### PR DESCRIPTION
## Integration tests failing in jenkins pipelines don't cause the stage to fail

- failing integration tests don't return non-zero exit code
- adding a github action to run the prepush script on PRs
[CB2-6735](https://dvsa.atlassian.net/browse/CB2-6735)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
