### PR TITLE
feat(cb2-6923): repair and test update endpoint for multiple vins

### DIFF
--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -357,6 +357,8 @@ export abstract class VehicleProcessor<T extends Vehicle> {
 
     VehicleProcessor.checkStatusCodeValidity(statusCode, oldStatusCode);
 
+    delete updatedVehicle.techRecord[0].historicVin;
+
     updatedVehicle.techRecord[0] = this.validate(updatedVehicle, false);
 
     try {

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -150,7 +150,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
       return vehiclesFromDB[0];
     }
     const filteredRecords = vehiclesFromDB.filter((record) => record.techRecord.find(findFn));
-    if (filteredRecords.length > 1) {
+    if (filteredRecords.length !== 1) {
       throw handlers.ErrorHandler.Error(500, enums.ERRORS.NO_UNIQUE_RECORD)
     }
     return filteredRecords[0];
@@ -484,9 +484,13 @@ export abstract class VehicleProcessor<T extends Vehicle> {
       enums.STATUS.ALL,
       enums.SEARCHCRITERIA.SYSTEM_NUMBER
     );
+
     if (data.length !== 1) {
       // systemNumber search should return a unique record
-      throw this.Error(500, enums.ERRORS.NO_UNIQUE_RECORD);
+      return VehicleProcessor.getTechRecordToUpdate(
+        data,
+        techRecord => techRecord.statusCode !== enums.STATUS.ARCHIVED
+      ) as T;
     }
     return data[0];
   }

--- a/tests/integration/updateTechRecordStatus.intTest.ts
+++ b/tests/integration/updateTechRecordStatus.intTest.ts
@@ -118,5 +118,31 @@ describe("UpdateTechRecordStatus", () => {
                     expect(JSON.parse(result.body).errors).toContain(HTTPRESPONSE.RESOURCE_NOT_FOUND);
                 });
         });
+
+        it("should return an error 200 and the updated vehicle with duplicate system number", async () => {
+            const systemNumber: string = "30000011";
+            expect.assertions(4);
+            await LambdaTester(updateTechRecordStatus)
+                .event({
+                    path: "/vehicles/update-status/" + systemNumber,
+                    pathParameters: {
+                      systemNumber,
+                    },
+                    queryStringParameters: {
+                        testStatus: "submitted",
+                        testResult: "pass",
+                        testTypeId: "47",
+                    },
+                    httpMethod: "PUT",
+                    resource: "/vehicles/update-status/{systemNumber}"
+                })
+                .expectResolve((result: any) => {
+                    expect(result.statusCode).toBe(200);
+                    const techRecordWrapper: ITechRecordWrapper = JSON.parse(result.body);
+                    expect(techRecordWrapper.techRecord.length).toBe(2);
+                    expect(techRecordWrapper.techRecord[0].statusCode).toBe(STATUS.ARCHIVED);
+                    expect(techRecordWrapper.techRecord[1].statusCode).toBe(STATUS.CURRENT);
+                });
+        });
     });
 });


### PR DESCRIPTION
## Update Tech Records still works with multiple VINs

Check and make sure that update endpoint still works with multiple vins. This repairs the code to allow it and adds tests.
[https://dvsa.atlassian.net/browse/CB2-6923](6923)

## Checklist

- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number
