### PR TITLE
Feat(cb2-7047): update compute record completeness with new wheels driven logic

### DIFF
--- a/src/utils/record-completeness/CoreMandatoryValidations.ts
+++ b/src/utils/record-completeness/CoreMandatoryValidations.ts
@@ -48,12 +48,12 @@ export const psvCoreMandatorySchema = coreMandatoryCommonSchemaPsvHgvTrl.keys({
   vehicleSize: Joi.string().valid(...VEHICLE_SIZE).required(),
   seatsLowerDeck: Joi.number().required(),
   seatsUpperDeck: Joi.number().required(),
-  numberOfWheelsDriven: Joi.number().required()
+  numberOfWheelsDriven: Joi.number().optional()
 }).required();
 
 export const trlCoreMandatorySchema = coreMandatoryCommonSchemaPsvHgvTrl;
 export const hgvCoreMandatorySchema = coreMandatoryCommonSchemaPsvHgvTrl.keys({
-  numberOfWheelsDriven: Joi.number().required()
+  numberOfWheelsDriven: Joi.number().optional()
 });
 
 export const carCoreMandatorySchema = coreMandatoryCommonSchemaLgvMotorcycleCar.keys({

--- a/tests/unit/ComputeRecordCompleteness.unitTest.ts
+++ b/tests/unit/ComputeRecordCompleteness.unitTest.ts
@@ -62,7 +62,7 @@ describe("Compute Record Completeness", () => {
       });
 
       it("should return SKELETON if one of the core-mandatory attributes is missing", () => {
-        const coreMandatoryFields = commonMandatoryFields.concat(["vehicleConfiguration", "vehicleClass", "vehicleSize", "seatsUpperDeck", "seatsLowerDeck", "numberOfWheelsDriven"]);
+        const coreMandatoryFields = commonMandatoryFields.concat(["vehicleConfiguration", "vehicleClass", "vehicleSize", "seatsUpperDeck", "seatsLowerDeck"]);
         for (const coreMandatoryField of coreMandatoryFields) {
           const record: any = cloneDeep(mockData[127]);
           delete (record.techRecord[0] as any)[coreMandatoryField];
@@ -98,7 +98,7 @@ describe("Compute Record Completeness", () => {
       });
 
       it("should return SKELETON if one of the core-mandatory attributes is missing", () => {
-        const coreMandatoryFields = commonMandatoryFields.concat(["vehicleConfiguration", "vehicleClass", "numberOfWheelsDriven"]);
+        const coreMandatoryFields = commonMandatoryFields.concat(["vehicleConfiguration", "vehicleClass"]);
         for (const coreMandatoryField of coreMandatoryFields) {
           const record: any = cloneDeep(mockData[125]);
           delete (record.techRecord[0] as any)[coreMandatoryField];


### PR DESCRIPTION
## Number of wheels driven not needed for testable record

Update the rec completeness calculation to not need wheels driven to be provided, except still on motorcycles.

[https://dvsa.atlassian.net/browse/CB2-7047](7047)

## Checklist

- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Squashed commit contains the JIRA ticket number
