### PR TITLE
feat(cb2-5698): added historic vrms to validation schemas

### DIFF
--- a/@Types/TechRecords.d.ts
+++ b/@Types/TechRecords.d.ts
@@ -36,6 +36,8 @@ export interface Trailer extends TrailerIdentifer {
 export interface TechRecord {
   hiddenInVta?: boolean;
   historicVin?: string;
+  historicPrimaryVrm?: string;
+  historicSecondaryVrms?: string[];
   recordCompleteness: string;
   euVehicleCategory: string;
   vehicleType: string;

--- a/src/utils/validations/CarValidations.ts
+++ b/src/utils/validations/CarValidations.ts
@@ -3,6 +3,8 @@ import {VEHICLE_CLASS_DESCRIPTION, VEHICLE_SUBCLASS} from "../../assets/Enums";
 import {commonSchemaLgvMotorcycleCar} from "./CommonSchema";
 
 export const carValidation = commonSchemaLgvMotorcycleCar.keys({
+  historicPrimaryVrm: Joi.string().optional(),
+  historicSecondaryVrms: Joi.array().items(Joi.string()).optional(),
   vehicleSubclass: Joi.array().items(Joi.string().valid(...VEHICLE_SUBCLASS)).required(),
   vehicleClass: Joi.object().keys({
     code: Joi.any().when("description", {

--- a/src/utils/validations/HgvValidations.ts
+++ b/src/utils/validations/HgvValidations.ts
@@ -4,6 +4,8 @@ import {FUEL_PROPULSION_SYSTEM} from "../../assets/Enums";
 import {adrValidation} from "./AdrValidation";
 
 export const hgvValidation = commonSchema.keys({
+  historicPrimaryVrm: Joi.string().optional(),
+  historicSecondaryVrms: Joi.array().items(Joi.string()).optional(),
   axles: Joi.array().items(axlesSchema.keys({
     weights: weightsSchema.keys({
       eecWeight: Joi.number().min(0).max(99999).optional().allow(null)

--- a/src/utils/validations/LgvValidations.ts
+++ b/src/utils/validations/LgvValidations.ts
@@ -3,6 +3,8 @@ import {VEHICLE_CLASS_DESCRIPTION, VEHICLE_SUBCLASS} from "../../assets/Enums";
 import {commonSchemaLgvMotorcycleCar} from "./CommonSchema";
 
 export const lgvValidation = commonSchemaLgvMotorcycleCar.keys({
+  historicPrimaryVrm: Joi.string().optional(),
+  historicSecondaryVrms: Joi.array().items(Joi.string()).optional(),
   vehicleSubclass: Joi.array().items(Joi.string().valid(...VEHICLE_SUBCLASS)).required(),
   vehicleClass: Joi.object().keys({
     code: Joi.any().when("description", {

--- a/src/utils/validations/MotorcycleValidations.ts
+++ b/src/utils/validations/MotorcycleValidations.ts
@@ -3,6 +3,8 @@ import {commonSchemaLgvMotorcycleCar} from "./CommonSchema";
 import {VEHICLE_CLASS_DESCRIPTION} from "../../assets/Enums";
 
 export const motorcycleValidation = commonSchemaLgvMotorcycleCar.keys({
+  historicPrimaryVrm: Joi.string().optional(),
+  historicSecondaryVrms: Joi.array().items(Joi.string()).optional(),
   numberOfWheelsDriven: Joi.number().min(0).max(9999).required(),
   vehicleClass: Joi.object().keys({
     code: Joi.any().when("description", {

--- a/src/utils/validations/PsvValidations.ts
+++ b/src/utils/validations/PsvValidations.ts
@@ -18,6 +18,8 @@ import {
 } from "./CommonSchema";
 
 export const psvValidation = commonSchema.keys({
+  historicPrimaryVrm: Joi.string().optional(),
+  historicSecondaryVrms: Joi.array().items(Joi.string()).optional(),
   brakeCode: Joi.string().optional(),
   brakes: brakesSchema.keys({
     brakeCode: Joi.string().max(6).required(),


### PR DESCRIPTION
## CB2-5698: Amend VRM

PR to add historic primary and secondary vrm fields to the joi schemas
[CB2-5698](https://dvsa.atlassian.net/browse/CB2-5698)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
