### PR TITLE
feat(cb2-7330): add historical vrms

### DIFF
--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -64,7 +64,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
   protected updateVehicleIdentifiers(existingVehicle: T, updatedVehicle: T): T {
     const { primaryVrm } = updatedVehicle;
     const previousPrimaryVrm = existingVehicle.primaryVrm;
-    updatedVehicle.secondaryVrms = existingVehicle.secondaryVrms ? Object.assign([], existingVehicle.secondaryVrms) : undefined
+    updatedVehicle.secondaryVrms = existingVehicle.secondaryVrms && [...existingVehicle.secondaryVrms]
 
     if (!primaryVrm || previousPrimaryVrm === primaryVrm) {
       return updatedVehicle;

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -410,30 +410,30 @@ export abstract class VehicleProcessor<T extends Vehicle> {
       updatedVehicle = this.updateVehicleIdentifiers(
         techRecordWithAllStatuses,
         updatedVehicle
-        );
-        updatedVehicle = this.capitaliseGeneralVehicleAttributes(updatedVehicle);
+      );
+      updatedVehicle = this.capitaliseGeneralVehicleAttributes(updatedVehicle);
         
-        if (updatedVehicle.techRecord[0].vehicleType === enums.VEHICLE_TYPE.TRL) {
-          // @ts-ignore
-          techRecordWithAllStatuses.trailerId = updatedVehicle.trailerId;
-        }
-        const newRecord: TechRecord = cloneDeep(techRecToArchive);
-        mergeWith(
-          newRecord,
-          updatedVehicle.techRecord[0],
-          VehicleProcessor.arrayCustomizer
-          );
-          if (oldStatusCode) {
-            newRecord.statusCode = statusCode;
-          }
-          newRecord.historicPrimaryVrm = undefined;
-          newRecord.historicSecondaryVrms = undefined;
-          console.log(techRecToArchive)
-          this.auditHandler.setAuditDetails(
-            newRecord,
-            techRecToArchive,
-            msUserDetails
-            );
+      if (updatedVehicle.techRecord[0].vehicleType === enums.VEHICLE_TYPE.TRL) {
+        // @ts-ignore
+        techRecordWithAllStatuses.trailerId = updatedVehicle.trailerId;
+      }
+      const newRecord: TechRecord = cloneDeep(techRecToArchive);
+      mergeWith(
+        newRecord,
+        updatedVehicle.techRecord[0],
+        VehicleProcessor.arrayCustomizer
+      );
+      if (oldStatusCode) {
+        newRecord.statusCode = statusCode;
+      }
+      newRecord.historicPrimaryVrm = undefined;
+      newRecord.historicSecondaryVrms = undefined;
+      console.log(techRecToArchive)
+      this.auditHandler.setAuditDetails(
+        newRecord,
+        techRecToArchive,
+        msUserDetails
+      );
       techRecToArchive.statusCode = enums.STATUS.ARCHIVED;
       this.mapFields(newRecord);
       const { systemNumber, vin, primaryVrm } = techRecordWithAllStatuses;

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -62,9 +62,11 @@ export abstract class VehicleProcessor<T extends Vehicle> {
    * @param updatedVehicle The updated tech record
    */
   protected updateVehicleIdentifiers(existingVehicle: T, updatedVehicle: T): T {
+    ;
     const { primaryVrm } = updatedVehicle;
     const previousPrimaryVrm = existingVehicle.primaryVrm;
-    updatedVehicle.secondaryVrms = existingVehicle.secondaryVrms;
+
+    updatedVehicle.secondaryVrms = Object.assign([], existingVehicle.secondaryVrms);
     if (!primaryVrm || previousPrimaryVrm === primaryVrm) {
       return updatedVehicle;
     }
@@ -72,8 +74,9 @@ export abstract class VehicleProcessor<T extends Vehicle> {
       updatedVehicle.secondaryVrms?.push(previousPrimaryVrm);
     }
     updatedVehicle.techRecord[0].reasonForCreation =
-      `VRM updated from ${previousPrimaryVrm} to ${primaryVrm}. ` +
-      updatedVehicle.techRecord[0].reasonForCreation;
+    `VRM updated from ${previousPrimaryVrm} to ${primaryVrm}. ` +
+    updatedVehicle.techRecord[0].reasonForCreation; 
+
 
     return updatedVehicle;
   }
@@ -390,8 +393,8 @@ export abstract class VehicleProcessor<T extends Vehicle> {
       const techRecToArchive = VehicleProcessor.getTechRecordToArchive(
         techRecordWithAllStatuses,
         oldStatusCode ? oldStatusCode : statusCode
-      );
-
+        );
+        
       // if status code has changed from provisional to current
       this.updateCurrentStatusCode(
         oldStatusCode,
@@ -400,16 +403,15 @@ export abstract class VehicleProcessor<T extends Vehicle> {
         msUserDetails
       );
 
+      techRecToArchive.historicPrimaryVrm = techRecordWithAllStatuses.primaryVrm
+      techRecToArchive.historicSecondaryVrms = techRecordWithAllStatuses.secondaryVrms;
+
       updatedVehicle = this.updateVehicleIdentifiers(
         techRecordWithAllStatuses,
-        updatedVehicle
+        updatedVehicle, 
       );
       updatedVehicle = this.capitaliseGeneralVehicleAttributes(updatedVehicle);
 
-      const originalRecord = await this.techRecordDAO.getBySearchTerm(updatedVehicle.systemNumber, enums.SEARCHCRITERIA.SYSTEM_NUMBER);
-
-      techRecToArchive.historicPrimaryVrm = originalRecord[0].primaryVrm;
-      techRecToArchive.historicSecondaryVrms = originalRecord[0].secondaryVrms;
       techRecordWithAllStatuses.primaryVrm = updatedVehicle.primaryVrm;
       techRecordWithAllStatuses.secondaryVrms = updatedVehicle.secondaryVrms;
       if (updatedVehicle.techRecord[0].vehicleType === enums.VEHICLE_TYPE.TRL) {

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -396,7 +396,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
       const techRecToArchive = VehicleProcessor.getTechRecordToArchive(
         techRecordWithAllStatuses,
         oldStatusCode ? oldStatusCode : statusCode
-        );
+      );
         
       techRecToArchive.historicPrimaryVrm = techRecordWithAllStatuses.primaryVrm
       techRecToArchive.historicSecondaryVrms = techRecordWithAllStatuses.secondaryVrms

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -428,7 +428,6 @@ export abstract class VehicleProcessor<T extends Vehicle> {
       }
       newRecord.historicPrimaryVrm = undefined;
       newRecord.historicSecondaryVrms = undefined;
-      console.log(techRecToArchive)
       this.auditHandler.setAuditDetails(
         newRecord,
         techRecToArchive,

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -65,14 +65,18 @@ export abstract class VehicleProcessor<T extends Vehicle> {
     ;
     const { primaryVrm } = updatedVehicle;
     const previousPrimaryVrm = existingVehicle.primaryVrm;
-
     updatedVehicle.secondaryVrms = existingVehicle.secondaryVrms ? Object.assign([], existingVehicle.secondaryVrms) : undefined
+
     if (!primaryVrm || previousPrimaryVrm === primaryVrm) {
       return updatedVehicle;
     }
     if (previousPrimaryVrm) {
       updatedVehicle.secondaryVrms?.push(previousPrimaryVrm);
     }
+
+    existingVehicle.primaryVrm = updatedVehicle.primaryVrm;
+    existingVehicle.secondaryVrms = updatedVehicle.secondaryVrms;
+    
     updatedVehicle.techRecord[0].reasonForCreation =
     `VRM updated from ${previousPrimaryVrm} to ${primaryVrm}. ` +
     updatedVehicle.techRecord[0].reasonForCreation; 
@@ -402,38 +406,34 @@ export abstract class VehicleProcessor<T extends Vehicle> {
         techRecordWithAllStatuses,
         msUserDetails
       );
-
-      techRecToArchive.historicPrimaryVrm = techRecordWithAllStatuses.primaryVrm
-      techRecToArchive.historicSecondaryVrms = techRecordWithAllStatuses.secondaryVrms;
-
+      
       updatedVehicle = this.updateVehicleIdentifiers(
         techRecordWithAllStatuses,
-        updatedVehicle, 
-      );
-      updatedVehicle = this.capitaliseGeneralVehicleAttributes(updatedVehicle);
-
-      techRecordWithAllStatuses.primaryVrm = updatedVehicle.primaryVrm;
-      techRecordWithAllStatuses.secondaryVrms = updatedVehicle.secondaryVrms;
-      if (updatedVehicle.techRecord[0].vehicleType === enums.VEHICLE_TYPE.TRL) {
-        // @ts-ignore
-        techRecordWithAllStatuses.trailerId = updatedVehicle.trailerId;
-      }
-      const newRecord: TechRecord = cloneDeep(techRecToArchive);
-      mergeWith(
-        newRecord,
-        updatedVehicle.techRecord[0],
-        VehicleProcessor.arrayCustomizer
-      );
-      if (oldStatusCode) {
-        newRecord.statusCode = statusCode;
-      }
-      newRecord.historicPrimaryVrm = undefined;
-      newRecord.historicSecondaryVrms = undefined;
-      this.auditHandler.setAuditDetails(
-        newRecord,
-        techRecToArchive,
-        msUserDetails
-      );
+        updatedVehicle
+        );
+        updatedVehicle = this.capitaliseGeneralVehicleAttributes(updatedVehicle);
+        
+        if (updatedVehicle.techRecord[0].vehicleType === enums.VEHICLE_TYPE.TRL) {
+          // @ts-ignore
+          techRecordWithAllStatuses.trailerId = updatedVehicle.trailerId;
+        }
+        const newRecord: TechRecord = cloneDeep(techRecToArchive);
+        mergeWith(
+          newRecord,
+          updatedVehicle.techRecord[0],
+          VehicleProcessor.arrayCustomizer
+          );
+          if (oldStatusCode) {
+            newRecord.statusCode = statusCode;
+          }
+          newRecord.historicPrimaryVrm = undefined;
+          newRecord.historicSecondaryVrms = undefined;
+          console.log(techRecToArchive)
+          this.auditHandler.setAuditDetails(
+            newRecord,
+            techRecToArchive,
+            msUserDetails
+            );
       techRecToArchive.statusCode = enums.STATUS.ARCHIVED;
       this.mapFields(newRecord);
       const { systemNumber, vin, primaryVrm } = techRecordWithAllStatuses;
@@ -552,7 +552,8 @@ export abstract class VehicleProcessor<T extends Vehicle> {
         `Vehicle has no tech-records with status ${statusCode}`
       );
     }
-
+    recordsToArchive[0].historicPrimaryVrm = techRecord.primaryVrm;
+    recordsToArchive[0].historicSecondaryVrms = techRecord.secondaryVrms;
     return recordsToArchive[0];
   }
 

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -66,7 +66,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
     const { primaryVrm } = updatedVehicle;
     const previousPrimaryVrm = existingVehicle.primaryVrm;
 
-    updatedVehicle.secondaryVrms = Object.assign([], existingVehicle.secondaryVrms);
+    updatedVehicle.secondaryVrms = existingVehicle.secondaryVrms ? Object.assign([], existingVehicle.secondaryVrms) : undefined
     if (!primaryVrm || previousPrimaryVrm === primaryVrm) {
       return updatedVehicle;
     }

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -399,6 +399,8 @@ export abstract class VehicleProcessor<T extends Vehicle> {
         oldStatusCode ? oldStatusCode : statusCode
         );
         
+      techRecToArchive.historicPrimaryVrm = techRecordWithAllStatuses.primaryVrm
+      techRecToArchive.historicSecondaryVrms = techRecordWithAllStatuses.secondaryVrms
       // if status code has changed from provisional to current
       this.updateCurrentStatusCode(
         oldStatusCode,
@@ -552,8 +554,6 @@ export abstract class VehicleProcessor<T extends Vehicle> {
         `Vehicle has no tech-records with status ${statusCode}`
       );
     }
-    recordsToArchive[0].historicPrimaryVrm = techRecord.primaryVrm;
-    recordsToArchive[0].historicSecondaryVrms = techRecord.secondaryVrms;
     return recordsToArchive[0];
   }
 

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -407,7 +407,6 @@ export abstract class VehicleProcessor<T extends Vehicle> {
         techRecordWithAllStatuses,
         msUserDetails
       );
-      
       updatedVehicle = this.updateVehicleIdentifiers(
         techRecordWithAllStatuses,
         updatedVehicle

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -406,6 +406,10 @@ export abstract class VehicleProcessor<T extends Vehicle> {
       );
       updatedVehicle = this.capitaliseGeneralVehicleAttributes(updatedVehicle);
 
+      const originalRecord = await this.techRecordDAO.getBySearchTerm(updatedVehicle.systemNumber, enums.SEARCHCRITERIA.SYSTEM_NUMBER);
+
+      techRecToArchive.historicPrimaryVrm = originalRecord[0].primaryVrm;
+      techRecToArchive.historicSecondaryVrms = originalRecord[0].secondaryVrms;
       techRecordWithAllStatuses.primaryVrm = updatedVehicle.primaryVrm;
       techRecordWithAllStatuses.secondaryVrms = updatedVehicle.secondaryVrms;
       if (updatedVehicle.techRecord[0].vehicleType === enums.VEHICLE_TYPE.TRL) {
@@ -421,6 +425,8 @@ export abstract class VehicleProcessor<T extends Vehicle> {
       if (oldStatusCode) {
         newRecord.statusCode = statusCode;
       }
+      newRecord.historicPrimaryVrm = undefined;
+      newRecord.historicSecondaryVrms = undefined;
       this.auditHandler.setAuditDetails(
         newRecord,
         techRecToArchive,

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -62,7 +62,6 @@ export abstract class VehicleProcessor<T extends Vehicle> {
    * @param updatedVehicle The updated tech record
    */
   protected updateVehicleIdentifiers(existingVehicle: T, updatedVehicle: T): T {
-    ;
     const { primaryVrm } = updatedVehicle;
     const previousPrimaryVrm = existingVehicle.primaryVrm;
     updatedVehicle.secondaryVrms = existingVehicle.secondaryVrms ? Object.assign([], existingVehicle.secondaryVrms) : undefined

--- a/tests/integration/techRecords.intTest.ts
+++ b/tests/integration/techRecords.intTest.ts
@@ -612,7 +612,6 @@ describe("techRecords", () => {
             });
           });
 
-
           context("and that vehicle does not exist", () => {
             it("should return error status 404 No resources match the search criteria", async () => {
               // @ts-ignore

--- a/tests/integration/techRecords.intTest.ts
+++ b/tests/integration/techRecords.intTest.ts
@@ -545,7 +545,6 @@ describe("techRecords", () => {
               await populateDatabase();
               const techRec = cloneDeep(mockData[132]) as ITechRecordWrapper;
               const primaryVrm = "ZYAG/ \\*-";
-
               const payload = {
                 msUserDetails,
                 primaryVrm,

--- a/tests/integration/techRecords.intTest.ts
+++ b/tests/integration/techRecords.intTest.ts
@@ -530,7 +530,7 @@ describe("techRecords", () => {
               const payload = {
                 msUserDetails,
                 primaryVrm,
-                techRecord: techRec.techRecord
+                techRecord: techRec.techRecord,
               };
               const res = await request.put(`vehicles/${techRec.systemNumber}`).send(payload);
               expect(res.status).toEqual(200);
@@ -539,6 +539,50 @@ describe("techRecords", () => {
               expect(res.body.techRecord).toHaveLength(techRec.techRecord.length + 1);
               expect(res.body.techRecord[techRec.techRecord.length].statusCode).toEqual("provisional");
               expect(res.body.techRecord[techRec.techRecord.length - 1].statusCode).toEqual("archived");
+            });
+
+            it("should populate the historic Vrms for auditing history", async () => {
+              await populateDatabase();
+              const techRec = cloneDeep(mockData[132]) as ITechRecordWrapper;
+              const primaryVrm = "ZYAG/ \\*-";
+
+              const payload = {
+                msUserDetails,
+                primaryVrm,
+                techRecord: techRec.techRecord,
+              };
+              const res = await request.put(`vehicles/${techRec.systemNumber}`).send(payload);
+              expect(res.status).toEqual(200);
+              expect(res.header["access-control-allow-origin"]).toEqual("*");
+              expect(res.header["access-control-allow-credentials"]).toEqual("true");
+              expect(res.body.techRecord).toHaveLength(techRec.techRecord.length + 1);
+              expect(res.body.techRecord[techRec.techRecord.length].statusCode).toEqual("provisional");
+              expect(res.body.techRecord[techRec.techRecord.length].historicPrimaryVrm).toBe(undefined);
+              expect(res.body.techRecord[techRec.techRecord.length - 1].statusCode).toEqual("archived");
+              expect(res.body.techRecord[techRec.techRecord.length - 1].historicPrimaryVrm).toEqual("B2C1C12");
+              expect(res.body.techRecord[techRec.techRecord.length - 1].historicSecondaryVrms).toEqual(["E5F1I00"]);
+            });
+
+            it("should also update the Vrms array to add the new primary vrm", async () => {
+              await populateDatabase();
+              const techRec = cloneDeep(mockData[132]) as ITechRecordWrapper;
+              const primaryVrm = "ZYAG/ \\*-";
+
+              const payload = {
+                msUserDetails,
+                primaryVrm,
+                techRecord: techRec.techRecord,
+              };
+              const expectedVrms = [
+                { vrm: "ZYAG/ \\*-", isPrimary: true },
+                { vrm: "E5F1I00", isPrimary: false },
+                { vrm: "B2C1C12", isPrimary: false },
+              ];
+              const res = await request.put(`vehicles/${techRec.systemNumber}`).send(payload);
+              expect(res.status).toEqual(200);
+              expect(res.header["access-control-allow-origin"]).toEqual("*");
+              expect(res.header["access-control-allow-credentials"]).toEqual("true");
+              expect(res.body.vrms).toEqual(expectedVrms);
             });
 
             it("should return status 200 and updated trailer with the updated trailer Id in upper case", async () => {
@@ -568,6 +612,7 @@ describe("techRecords", () => {
               ).toEqual("archived");
             });
           });
+
 
           context("and that vehicle does not exist", () => {
             it("should return error status 404 No resources match the search criteria", async () => {


### PR DESCRIPTION
CB2-7330
CB2- 5698

Work to retain historical VRM's so they show as the primary and secondary vrms as they were at the time the record was archived.