### PR TITLE
fix(cb2-7504): fully update the new tech records instead of merging it with the old

### DIFF
--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -412,12 +412,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
         // @ts-ignore
         techRecordWithAllStatuses.trailerId = updatedVehicle.trailerId;
       }
-      const newRecord: TechRecord = cloneDeep(techRecToArchive);
-      mergeWith(
-        newRecord,
-        updatedVehicle.techRecord[0],
-        VehicleProcessor.arrayCustomizer
-      );
+      const newRecord: TechRecord = cloneDeep(updatedVehicle.techRecord[0]);
       if (oldStatusCode) {
         newRecord.statusCode = statusCode;
       }


### PR DESCRIPTION
## Updating Vehicle Type Retains Old Properties, When It Should Not

[CB2-7504](https://dvsa.atlassian.net/browse/CB2-7504)