### PR TITLE
feat(cb2-6178): remove push to secondary vrms

### DIFF
--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -64,10 +64,12 @@ export abstract class VehicleProcessor<T extends Vehicle> {
   protected updateVehicleIdentifiers(existingVehicle: T, updatedVehicle: T): T {
     const { primaryVrm } = updatedVehicle;
     const previousPrimaryVrm = existingVehicle.primaryVrm;
-    existingVehicle.secondaryVrms = updatedVehicle.secondaryVrms;
     if (!primaryVrm || previousPrimaryVrm === primaryVrm) {
       return updatedVehicle;
     }
+
+    existingVehicle.primaryVrm = updatedVehicle.primaryVrm;
+    existingVehicle.secondaryVrms = updatedVehicle.secondaryVrms;
 
     updatedVehicle.techRecord[0].reasonForCreation =
     `VRM updated from ${previousPrimaryVrm} to ${primaryVrm}. ` +

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -68,9 +68,6 @@ export abstract class VehicleProcessor<T extends Vehicle> {
     if (!primaryVrm || previousPrimaryVrm === primaryVrm) {
       return updatedVehicle;
     }
-    if (previousPrimaryVrm) {
-      updatedVehicle.secondaryVrms?.push(previousPrimaryVrm);
-    }
     updatedVehicle.techRecord[0].reasonForCreation =
       `VRM updated from ${previousPrimaryVrm} to ${primaryVrm}. ` +
       updatedVehicle.techRecord[0].reasonForCreation;

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -64,6 +64,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
   protected updateVehicleIdentifiers(existingVehicle: T, updatedVehicle: T): T {
     const { primaryVrm } = updatedVehicle;
     const previousPrimaryVrm = existingVehicle.primaryVrm;
+    updatedVehicle.secondaryVrms = existingVehicle.secondaryVrms;
     if (!primaryVrm || previousPrimaryVrm === primaryVrm) {
       return updatedVehicle;
     }

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -64,6 +64,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
   protected updateVehicleIdentifiers(existingVehicle: T, updatedVehicle: T): T {
     const { primaryVrm } = updatedVehicle;
     const previousPrimaryVrm = existingVehicle.primaryVrm;
+    existingVehicle.secondaryVrms = updatedVehicle.secondaryVrms;
     if (!primaryVrm || previousPrimaryVrm === primaryVrm) {
       return updatedVehicle;
     }

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -64,17 +64,19 @@ export abstract class VehicleProcessor<T extends Vehicle> {
   protected updateVehicleIdentifiers(existingVehicle: T, updatedVehicle: T): T {
     const { primaryVrm } = updatedVehicle;
     const previousPrimaryVrm = existingVehicle.primaryVrm;
-    if (!primaryVrm || previousPrimaryVrm === primaryVrm) {
-      return updatedVehicle;
-    }
 
     existingVehicle.primaryVrm = updatedVehicle.primaryVrm;
     existingVehicle.secondaryVrms = updatedVehicle.secondaryVrms;
+
+    if (!primaryVrm || previousPrimaryVrm === primaryVrm) {
+      return updatedVehicle;
+    }
 
     updatedVehicle.techRecord[0].reasonForCreation =
     `VRM updated from ${previousPrimaryVrm} to ${primaryVrm}. ` +
     updatedVehicle.techRecord[0].reasonForCreation; 
 
+    console.log(existingVehicle.secondaryVrms);
 
     return updatedVehicle;
   }

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -64,7 +64,6 @@ export abstract class VehicleProcessor<T extends Vehicle> {
   protected updateVehicleIdentifiers(existingVehicle: T, updatedVehicle: T): T {
     const { primaryVrm } = updatedVehicle;
     const previousPrimaryVrm = existingVehicle.primaryVrm;
-    updatedVehicle.secondaryVrms = existingVehicle.secondaryVrms;
     if (!primaryVrm || previousPrimaryVrm === primaryVrm) {
       return updatedVehicle;
     }

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -64,7 +64,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
   protected updateVehicleIdentifiers(existingVehicle: T, updatedVehicle: T): T {
     const { primaryVrm } = updatedVehicle;
     const previousPrimaryVrm = existingVehicle.primaryVrm;
-    updatedVehicle.secondaryVrms = existingVehicle.secondaryVrms;
+    existingVehicle.secondaryVrms = updatedVehicle.secondaryVrms;
     if (!primaryVrm || previousPrimaryVrm === primaryVrm) {
       return updatedVehicle;
     }

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -64,7 +64,6 @@ export abstract class VehicleProcessor<T extends Vehicle> {
   protected updateVehicleIdentifiers(existingVehicle: T, updatedVehicle: T): T {
     const { primaryVrm } = updatedVehicle;
     const previousPrimaryVrm = existingVehicle.primaryVrm;
-    existingVehicle.secondaryVrms = updatedVehicle.secondaryVrms;
     if (!primaryVrm || previousPrimaryVrm === primaryVrm) {
       return updatedVehicle;
     }

--- a/src/models/TechRecordsDAO.ts
+++ b/src/models/TechRecordsDAO.ts
@@ -152,7 +152,7 @@ class TechRecordsDAO {
         ":primaryVrm": primaryVrm,
       });
     }
-    if (secondaryVrms && secondaryVrms.length) {
+    if (secondaryVrms) {
       query.UpdateExpression += ", secondaryVrms = :secondaryVrms";
       Object.assign(query.ExpressionAttributeValues, {
         ":secondaryVrms": secondaryVrms,

--- a/src/models/TechRecordsDAO.ts
+++ b/src/models/TechRecordsDAO.ts
@@ -152,7 +152,7 @@ class TechRecordsDAO {
         ":primaryVrm": primaryVrm,
       });
     }
-    if (secondaryVrms) {
+    if (secondaryVrms && secondaryVrms.length) {
       query.UpdateExpression += ", secondaryVrms = :secondaryVrms";
       Object.assign(query.ExpressionAttributeValues, {
         ":secondaryVrms": secondaryVrms,

--- a/tests/integration/techRecords.intTest.ts
+++ b/tests/integration/techRecords.intTest.ts
@@ -565,7 +565,7 @@ describe("techRecords", () => {
             it("should also update the Vrms array to add the new primary vrm", async () => {
               await populateDatabase();
               const techRec = cloneDeep(mockData[132]) as ITechRecordWrapper;
-              const primaryVrm = "ZYAG/ \\*-";
+              const primaryVrm = "NEWVRM";
 
               const payload = {
                 msUserDetails,
@@ -573,9 +573,8 @@ describe("techRecords", () => {
                 techRecord: techRec.techRecord,
               };
               const expectedVrms = [
-                { vrm: "ZYAG/ \\*-", isPrimary: true },
+                { vrm: "NEWVRM", isPrimary: true },
                 { vrm: "E5F1I00", isPrimary: false },
-                { vrm: "B2C1C12", isPrimary: false },
               ];
               const res = await request.put(`vehicles/${techRec.systemNumber}`).send(payload);
               expect(res.status).toEqual(200);

--- a/tests/unit/domain/updateVehicle.unitTest.ts
+++ b/tests/unit/domain/updateVehicle.unitTest.ts
@@ -236,8 +236,6 @@ describe("VehicleProcessor", () => {
                       payload
                     );
                     expect(updatedVehicle.primaryVrm).toEqual("ABCD943");
-                    expect(updatedVehicle.secondaryVrms?.length).toEqual(2);
-                    expect(updatedVehicle.secondaryVrms).toContain("B999XFX");
                     expect(updatedVehicle.techRecord[0].reasonForCreation).toEqual(
                       `VRM updated from B999XFX to ABCD943. Updated VRM`
                     );
@@ -343,8 +341,6 @@ describe("VehicleProcessor", () => {
                       payload
                     );
                     expect(updatedVehicle.primaryVrm).toEqual("AA12BCD");
-                    expect(updatedVehicle.secondaryVrms?.length).toEqual(2);
-                    expect(updatedVehicle.secondaryVrms).toContain("B999XFX");
                     expect(updatedVehicle.techRecord[0].reasonForCreation).toEqual(
                       `VRM updated from B999XFX to AA12BCD. Updated VRM`
                     );

--- a/tests/unit/domain/updateVehicle.unitTest.ts
+++ b/tests/unit/domain/updateVehicle.unitTest.ts
@@ -481,7 +481,7 @@ describe("VehicleProcessor", () => {
                 const MockDAO = jest.fn().mockImplementation();
                 // @ts-ignore;
                 const payload: Trailer = cloneDeep(mockData[43]);
-                payload.secondaryVrms = ["ABCD943"];
+                payload.secondaryVrms = ["ABCD943", "BCDE132"];
                 const trailerProcessor = new TrailerProcessor(
                   payload,
                   new MockDAO()
@@ -491,7 +491,7 @@ describe("VehicleProcessor", () => {
                   techRecord,
                   payload
                 );
-                expect(techRecord.secondaryVrms).toEqual(["ABCD943"]);
+                expect(techRecord.secondaryVrms).toEqual(["ABCD943", "BCDE132"]);
               });
             });
             context("and the new secondaryVrms are invalid", () => {

--- a/tests/unit/domain/updateVehicle.unitTest.ts
+++ b/tests/unit/domain/updateVehicle.unitTest.ts
@@ -488,8 +488,8 @@ describe("VehicleProcessor", () => {
                 );
                 // @ts-ignore
                 trailerProcessor.updateVehicleIdentifiers(
-                  payload,
-                  techRecord
+                  techRecord,
+                  payload
                 );
                 expect(techRecord.secondaryVrms).toEqual(["ABCD943"]);
               });


### PR DESCRIPTION
## CB2-6178: Amend VRM with cherished transfer

Removes lines of code to add the old primary VRM to the secondary array, which is functionality we don't want when amending the VRM to correct an error - the payload for the new primary and secondary VRMs is provided by VTM
[CB2-6178](https://dvsa.atlassian.net/browse/CB2-6178)
[CB2-5698](https://dvsa.atlassian.net/browse/CB2-5698)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
