### PR TITLE
fix(cb2-7535): skeleton psv records can't change vrm

### DIFF
--- a/src/domain/Processors/PsvProcessor.ts
+++ b/src/domain/Processors/PsvProcessor.ts
@@ -35,9 +35,10 @@ export class PsvProcessor extends VehicleProcessor<PublicServiceVehicle> {
     techRecord.vehicleClass.code = validators.populateVehicleClassCode(
       techRecord.vehicleClass.description
     );
-    techRecord.brakes.brakeCodeOriginal = techRecord.brakes.brakeCode.substring(
+     if(techRecord.brakes.brakeCode) {
+      techRecord.brakes.brakeCodeOriginal = techRecord.brakes.brakeCode.substring(
       techRecord.brakes.brakeCode.length - 3
-    );
+    )};
     techRecord.brakeCode = techRecord.brakes.brakeCode;
     return techRecord;
   }


### PR DESCRIPTION
CB2-7535:

techRecord.brakes.brakeCode can be sent undefined, this causes an error which doesn't get caught, I think this will allow PSV skeleton records to change VRM