### PR TITLE
feat(cb2-7330) Retain VRM's on archive

### DIFF
--- a/@Types/ITechRecord.d.ts
+++ b/@Types/ITechRecord.d.ts
@@ -124,6 +124,8 @@ export default interface ITechRecord {
   manufacturerDetails: ManufacturerDetails;
   authIntoService: AuthIntoService;
   lettersOfAuth: LettersOfAuth;
+  historicPrimaryVrm?: string;
+  historicSecondaryVrms?: string[];
 }
 
 interface Dimensions {

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -268,7 +268,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
         techRecordToUpdate.techRecord[0].statusCode === techRecord.statusCode
     );
 
-    const techRecordWithAllStatues = allTechRecordWrapper[0];
+    const techRecordWithAllStatuses = allTechRecordWrapper[0];
     const techRecordToArchive = VehicleProcessor.getTechRecordToArchive(
       uniqueVehicleRecord,
       techRecordToUpdate.techRecord[0].statusCode

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -258,8 +258,8 @@ export abstract class VehicleProcessor<T extends Vehicle> {
     techRecordToArchive.lastUpdatedByName = userDetails.msUser;
     techRecordToArchive.lastUpdatedById = userDetails.msOid;
     techRecordToArchive.updateType = enums.UPDATE_TYPE.TECH_RECORD_UPDATE;
-    techRecordWithAllStatuses.techRecord[0].historicPrimaryVrm = techRecordWithAllStatuses.primaryVrm;
-    techRecordWithAllStatuses.techRecord[0].historicSecondaryVrms = techRecordWithAllStatuses.secondaryVrms;
+    techRecordToArchive.historicPrimaryVrm = techRecordWithAllStatuses.primaryVrm;
+    techRecordToArchive.historicSecondaryVrms = techRecordWithAllStatuses.secondaryVrms;
     if (techRecordToArchive.vehicleType === enums.VEHICLE_TYPE.PSV) {
       const remarks = (techRecordToArchive as PsvTechRecord).remarks;
       (techRecordToArchive as PsvTechRecord).remarks = remarks

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -76,8 +76,6 @@ export abstract class VehicleProcessor<T extends Vehicle> {
     `VRM updated from ${previousPrimaryVrm} to ${primaryVrm}. ` +
     updatedVehicle.techRecord[0].reasonForCreation; 
 
-    console.log(existingVehicle.secondaryVrms);
-
     return updatedVehicle;
   }
 
@@ -244,9 +242,9 @@ export abstract class VehicleProcessor<T extends Vehicle> {
       // systemNumber search should return a single record
       throw this.Error(400, enums.ERRORS.NO_UNIQUE_RECORD);
     }
-    const techRecordWithAllStatues = allTechRecordWrapper[0];
+    const techRecordWithAllStatuses = allTechRecordWrapper[0];
     const techRecordToArchive = VehicleProcessor.getTechRecordToArchive(
-      techRecordWithAllStatues,
+      techRecordWithAllStatuses,
       techRecordToUpdate.techRecord[0].statusCode
     );
     if (techRecordToArchive.statusCode === enums.STATUS.ARCHIVED) {
@@ -260,6 +258,8 @@ export abstract class VehicleProcessor<T extends Vehicle> {
     techRecordToArchive.lastUpdatedByName = userDetails.msUser;
     techRecordToArchive.lastUpdatedById = userDetails.msOid;
     techRecordToArchive.updateType = enums.UPDATE_TYPE.TECH_RECORD_UPDATE;
+    techRecordWithAllStatuses.techRecord[0].historicPrimaryVrm = techRecordWithAllStatuses.primaryVrm;
+    techRecordWithAllStatuses.techRecord[0].historicSecondaryVrms = techRecordWithAllStatuses.secondaryVrms;
     if (techRecordToArchive.vehicleType === enums.VEHICLE_TYPE.PSV) {
       const remarks = (techRecordToArchive as PsvTechRecord).remarks;
       (techRecordToArchive as PsvTechRecord).remarks = remarks
@@ -275,7 +275,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
     let updatedTechRecord;
     try {
       updatedTechRecord = await this.techRecordDAO.updateSingle(
-        techRecordWithAllStatues
+        techRecordWithAllStatuses
       );
     } catch (error) {
       console.error(error);

--- a/tests/integration/archiveTechRecordStatus.intTest.ts
+++ b/tests/integration/archiveTechRecordStatus.intTest.ts
@@ -18,17 +18,11 @@ const msUserDetails = {
 describe("archiveTechRecordStatus", () => {
   beforeAll(async () => {
     jest.restoreAllMocks();
-    // await emptyDatabase();
-    await populateDatabase();
   });
   beforeEach(async () => {
-    // await populateDatabase();
-  });
-  afterEach(async () => {
-    // await emptyDatabase();
+    await populateDatabase();
   });
   afterAll(async () => {
-    // await populateDatabase();
     await emptyDatabase();
   });
 
@@ -69,6 +63,38 @@ describe("archiveTechRecordStatus", () => {
             expect(techRecordWrapper.techRecord[0].notes).toBe(
               "string\nTest"
             );
+          });
+      });
+      it("should populate the historic vrm's", async () => {
+        const systemNumber: string = "1100047";
+        const techRecord: any = cloneDeep(mockData[43]);
+        const payload = {
+          vin: techRecord.vin,
+          reasonForArchiving: "Test",
+          systemNumber: techRecord.systemNumber,
+          primaryVrm: techRecord.primaryVrm,
+          msUserDetails,
+          techRecord: techRecord.techRecord
+        };
+        expect.assertions(3);
+        await LambdaTester(archiveTechRecordStatus)
+          .event({
+            path: `/vehicles/archive/${systemNumber}`,
+            pathParameters: {
+              systemNumber
+            },
+            queryStringParameters: {},
+            body: payload,
+            httpMethod: "PUT",
+            resource: "/vehicles/archive/{systemNumber}"
+          })
+          .expectResolve((result: any) => {
+            expect(result.statusCode).toBe(200);
+            const techRecordWrapper: ITechRecordWrapper = JSON.parse(
+              result.body
+            );
+            expect(techRecordWrapper.techRecord[0].historicPrimaryVrm).toEqual(techRecord.primaryVrm);
+            expect(techRecordWrapper.techRecord[0].historicSecondaryVrms).toEqual(techRecord.secondaryVrms);
           });
       });
     }

--- a/tests/integration/archiveTechRecordStatus.intTest.ts
+++ b/tests/integration/archiveTechRecordStatus.intTest.ts
@@ -66,8 +66,8 @@ describe("archiveTechRecordStatus", () => {
           });
       });
       it("should populate the historic vrm's", async () => {
-        const systemNumber: string = "1100047";
-        const techRecord: any = cloneDeep(mockData[43]);
+        const systemNumber: string = "11000009";
+        const techRecord: any = cloneDeep(mockData[8]);
         const payload = {
           vin: techRecord.vin,
           reasonForArchiving: "Test",

--- a/tests/resources/technical-records.json
+++ b/tests/resources/technical-records.json
@@ -40481,5 +40481,1673 @@
         "vehicleType": "car"
       }
     ]
+  },
+  {
+    "systemNumber": "5976332",
+    "vin": "AA11100800",
+    "partialVin": "100800",
+    "primaryVrm": "CA01SCR",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T10:39:47.000000Z",
+        "euVehicleCategory": "m1",
+        "lastUpdatedAt": "2023-02-09T20:45:45.000000Z",
+        "make": "HONDA",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "2",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "4",
+          "description": "MOT class 4"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+          "A"
+        ],
+        "vehicleType": "car"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5976333",
+    "vin": "AA11100801",
+    "partialVin": "100801",
+    "primaryVrm": "CA01SCA",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T10:39:47.000000Z",
+        "euVehicleCategory": "m1",
+        "lastUpdatedAt": "2023-02-09T20:45:45.000000Z",
+        "make": "HONDA",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "2",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "4",
+          "description": "MOT class 4"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+          "A"
+        ],
+        "vehicleType": "car"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5976334",
+    "vin": "AA11100802",
+    "partialVin": "100802",
+    "primaryVrm": "CA01SCC",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T10:39:47.000000Z",
+        "euVehicleCategory": "m1",
+        "lastUpdatedAt": "2023-02-09T20:45:45.000000Z",
+        "make": "HONDA",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "2",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "4",
+          "description": "MOT class 4"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+          "C"
+        ],
+        "vehicleType": "car"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5976335",
+    "vin": "AA11100804",
+    "partialVin": "100804",
+    "primaryVrm": "CA01SCS",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T10:39:47.000000Z",
+        "euVehicleCategory": "m1",
+        "lastUpdatedAt": "2023-02-09T20:45:45.000000Z",
+        "make": "HONDA",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "2",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "4",
+          "description": "MOT class 4"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+          "S"
+        ],
+        "vehicleType": "car"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5976336",
+    "vin": "AA11100806",
+    "partialVin": "100806",
+    "primaryVrm": "CA01SCL",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T10:39:47.000000Z",
+        "euVehicleCategory": "m1",
+        "lastUpdatedAt": "2023-02-09T20:45:45.000000Z",
+        "make": "HONDA",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "2",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "4",
+          "description": "MOT class 4"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+          "L"
+        ],
+        "vehicleType": "car"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5976337",
+    "vin": "AA11100807",
+    "partialVin": "100807",
+    "primaryVrm": "CA01SCM",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T10:39:47.000000Z",
+        "euVehicleCategory": "m1",
+        "lastUpdatedAt": "2023-02-09T20:45:45.000000Z",
+        "make": "HONDA",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "2",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "4",
+          "description": "MOT class 4"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+          "M"
+        ],
+        "vehicleType": "car"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5976338",
+    "vin": "AA11100808",
+    "partialVin": "100808",
+    "primaryVrm": "CA01SCP",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T10:39:47.000000Z",
+        "euVehicleCategory": "m1",
+        "lastUpdatedAt": "2023-02-09T20:45:45.000000Z",
+        "make": "HONDA",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "2",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "4",
+          "description": "MOT class 4"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+          "P"
+        ],
+        "vehicleType": "car"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5976339",
+    "vin": "AA11100809",
+    "partialVin": "100809",
+    "primaryVrm": "CA01SCN",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T10:39:47.000000Z",
+        "euVehicleCategory": "m1",
+        "lastUpdatedAt": "2023-02-09T20:45:45.000000Z",
+        "make": "HONDA",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "2",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "4",
+          "description": "MOT class 4"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+          "N"
+        ],
+        "vehicleType": "car"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5976310",
+    "vin": "AA11100810",
+    "partialVin": "100810",
+    "primaryVrm": "CA01SBT",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T10:39:47.000000Z",
+        "euVehicleCategory": "m1",
+        "lastUpdatedAt": "2023-02-09T20:45:45.000000Z",
+        "make": "HONDA",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "2",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "4",
+          "description": "MOT class 4"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+          "T"
+        ],
+        "vehicleType": "car"
+      }
+    ]
+  },
+  {
+    "systemNumber": "1100311",
+    "vin": "P0123010951211",
+    "partialVin": "951211",
+    "primaryVrm": "LG01SCR",
+    "secondaryVrms": [
+      "AS432TY"
+    ],
+    "techRecord": [
+      {
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": null,
+              "fitmentCode": null,
+              "plyRating": null,
+              "speedCategorySymbol": "a7",
+              "tyreCode": null,
+              "tyreSize": null
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 345,
+              "fitmentCode": "single",
+              "plyRating": "AB",
+              "speedCategorySymbol": "a7",
+              "tyreCode": 5678,
+              "tyreSize": "295/80-22.5"
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "x",
+          "description": null
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "antilockBrakingSystem": true,
+          "brakeCode": "123",
+          "brakeCodeOriginal": "12412",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2332,
+            "secondaryBrakeForceA": 2512,
+            "serviceBrakeForceA": 6424
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 3512,
+            "secondaryBrakeForceB": 2512,
+            "serviceBrakeForceB": 5521
+          },
+          "dataTrBrakeOne": "None",
+          "dataTrBrakeThree": "None",
+          "dataTrBrakeTwo": "None",
+          "dtpNumber": null,
+          "loadSensingValve": true,
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "exhaust"
+        },
+        "conversionRefNo": null,
+        "createdAt": "2019-06-24T10:26:54.903Z",
+        "createdByName": null,
+        "dimensions": {
+          "length": null,
+          "width": null
+        },
+        "drawbarCouplingFitted": null,
+        "euroStandard": " ",
+        "euVehicleCategory": "n1",
+        "frontAxleTo5thWheelCouplingMax": null,
+        "frontAxleTo5thWheelCouplingMin": null,
+        "frontAxleTo5thWheelMax": null,
+        "frontAxleTo5thWheelMin": null,
+        "functionCode": null,
+        "grossDesignWeight": null,
+        "grossGbWeight": null,
+        "grossKerbWeight": null,
+        "grossLadenWeight": null,
+        "lastUpdatedAt": "2019-06-24T10:26:54.903Z",
+        "make": null,
+        "manufactureYear": null,
+        "maxTrainDesignWeight": null,
+        "maxTrainGbWeight": null,
+        "model": null,
+        "noOfAxles": 2,
+        "notes": null,
+        "ntaNumber": null,
+        "numberOfWheelsDriven": null,
+        "reasonForCreation": null,
+        "recordCompleteness": "complete",
+        "roadFriendly": false,
+        "speedLimiterMrk": null,
+        "statusCode": "current",
+        "tachoExemptMrk": null,
+        "trainDesignWeight": null,
+        "trainGbWeight": null,
+        "tyreUseCode": null,
+        "vehicleClass": {
+          "code": "v",
+          "description": "3 wheelers"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSubclass": [
+          "R"
+        ],
+        "vehicleType": "lgv"
+      }
+    ]
+  },
+  {
+    "systemNumber": "1100312",
+    "vin": "P0123010951212",
+    "partialVin": "951212",
+    "primaryVrm": "LG01SCA",
+    "secondaryVrms": [
+      "AS432TY"
+    ],
+    "techRecord": [
+      {
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": null,
+              "fitmentCode": null,
+              "plyRating": null,
+              "speedCategorySymbol": "a7",
+              "tyreCode": null,
+              "tyreSize": null
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 345,
+              "fitmentCode": "single",
+              "plyRating": "AB",
+              "speedCategorySymbol": "a7",
+              "tyreCode": 5678,
+              "tyreSize": "295/80-22.5"
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "x",
+          "description": null
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "antilockBrakingSystem": true,
+          "brakeCode": "123",
+          "brakeCodeOriginal": "12412",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2332,
+            "secondaryBrakeForceA": 2512,
+            "serviceBrakeForceA": 6424
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 3512,
+            "secondaryBrakeForceB": 2512,
+            "serviceBrakeForceB": 5521
+          },
+          "dataTrBrakeOne": "None",
+          "dataTrBrakeThree": "None",
+          "dataTrBrakeTwo": "None",
+          "dtpNumber": null,
+          "loadSensingValve": true,
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "exhaust"
+        },
+        "conversionRefNo": null,
+        "createdAt": "2019-06-24T10:26:54.903Z",
+        "createdByName": null,
+        "dimensions": {
+          "length": null,
+          "width": null
+        },
+        "drawbarCouplingFitted": null,
+        "euroStandard": " ",
+        "euVehicleCategory": "n1",
+        "frontAxleTo5thWheelCouplingMax": null,
+        "frontAxleTo5thWheelCouplingMin": null,
+        "frontAxleTo5thWheelMax": null,
+        "frontAxleTo5thWheelMin": null,
+        "functionCode": null,
+        "grossDesignWeight": null,
+        "grossGbWeight": null,
+        "grossKerbWeight": null,
+        "grossLadenWeight": null,
+        "lastUpdatedAt": "2019-06-24T10:26:54.903Z",
+        "make": null,
+        "manufactureYear": null,
+        "maxTrainDesignWeight": null,
+        "maxTrainGbWeight": null,
+        "model": null,
+        "noOfAxles": 2,
+        "notes": null,
+        "ntaNumber": null,
+        "numberOfWheelsDriven": null,
+        "reasonForCreation": null,
+        "recordCompleteness": "complete",
+        "roadFriendly": false,
+        "speedLimiterMrk": null,
+        "statusCode": "current",
+        "tachoExemptMrk": null,
+        "trainDesignWeight": null,
+        "trainGbWeight": null,
+        "tyreUseCode": null,
+        "vehicleClass": {
+          "code": "v",
+          "description": "3 wheelers"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSubclass": [
+          "A"
+        ],
+        "vehicleType": "lgv"
+      }
+    ]
+  },
+  {
+    "systemNumber": "1100313",
+    "vin": "P0123010951213",
+    "partialVin": "951213",
+    "primaryVrm": "LG01SCC",
+    "secondaryVrms": [
+      "AS432TY"
+    ],
+    "techRecord": [
+      {
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": null,
+              "fitmentCode": null,
+              "plyRating": null,
+              "speedCategorySymbol": "a7",
+              "tyreCode": null,
+              "tyreSize": null
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 345,
+              "fitmentCode": "single",
+              "plyRating": "AB",
+              "speedCategorySymbol": "a7",
+              "tyreCode": 5678,
+              "tyreSize": "295/80-22.5"
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "x",
+          "description": null
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "antilockBrakingSystem": true,
+          "brakeCode": "123",
+          "brakeCodeOriginal": "12412",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2332,
+            "secondaryBrakeForceA": 2512,
+            "serviceBrakeForceA": 6424
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 3512,
+            "secondaryBrakeForceB": 2512,
+            "serviceBrakeForceB": 5521
+          },
+          "dataTrBrakeOne": "None",
+          "dataTrBrakeThree": "None",
+          "dataTrBrakeTwo": "None",
+          "dtpNumber": null,
+          "loadSensingValve": true,
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "exhaust"
+        },
+        "conversionRefNo": null,
+        "createdAt": "2019-06-24T10:26:54.903Z",
+        "createdByName": null,
+        "dimensions": {
+          "length": null,
+          "width": null
+        },
+        "drawbarCouplingFitted": null,
+        "euroStandard": " ",
+        "euVehicleCategory": "n1",
+        "frontAxleTo5thWheelCouplingMax": null,
+        "frontAxleTo5thWheelCouplingMin": null,
+        "frontAxleTo5thWheelMax": null,
+        "frontAxleTo5thWheelMin": null,
+        "functionCode": null,
+        "grossDesignWeight": null,
+        "grossGbWeight": null,
+        "grossKerbWeight": null,
+        "grossLadenWeight": null,
+        "lastUpdatedAt": "2019-06-24T10:26:54.903Z",
+        "make": null,
+        "manufactureYear": null,
+        "maxTrainDesignWeight": null,
+        "maxTrainGbWeight": null,
+        "model": null,
+        "noOfAxles": 2,
+        "notes": null,
+        "ntaNumber": null,
+        "numberOfWheelsDriven": null,
+        "reasonForCreation": null,
+        "recordCompleteness": "complete",
+        "roadFriendly": false,
+        "speedLimiterMrk": null,
+        "statusCode": "current",
+        "tachoExemptMrk": null,
+        "trainDesignWeight": null,
+        "trainGbWeight": null,
+        "tyreUseCode": null,
+        "vehicleClass": {
+          "code": "v",
+          "description": "3 wheelers"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSubclass": [
+          "C"
+        ],
+        "vehicleType": "lgv"
+      }
+    ]
+  },
+  {
+    "systemNumber": "1100314",
+    "vin": "P0123010951214",
+    "partialVin": "951214",
+    "primaryVrm": "LG01SCS",
+    "secondaryVrms": [
+      "AS432TY"
+    ],
+    "techRecord": [
+      {
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": null,
+              "fitmentCode": null,
+              "plyRating": null,
+              "speedCategorySymbol": "a7",
+              "tyreCode": null,
+              "tyreSize": null
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 345,
+              "fitmentCode": "single",
+              "plyRating": "AB",
+              "speedCategorySymbol": "a7",
+              "tyreCode": 5678,
+              "tyreSize": "295/80-22.5"
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "x",
+          "description": null
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "antilockBrakingSystem": true,
+          "brakeCode": "123",
+          "brakeCodeOriginal": "12412",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2332,
+            "secondaryBrakeForceA": 2512,
+            "serviceBrakeForceA": 6424
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 3512,
+            "secondaryBrakeForceB": 2512,
+            "serviceBrakeForceB": 5521
+          },
+          "dataTrBrakeOne": "None",
+          "dataTrBrakeThree": "None",
+          "dataTrBrakeTwo": "None",
+          "dtpNumber": null,
+          "loadSensingValve": true,
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "exhaust"
+        },
+        "conversionRefNo": null,
+        "createdAt": "2019-06-24T10:26:54.903Z",
+        "createdByName": null,
+        "dimensions": {
+          "length": null,
+          "width": null
+        },
+        "drawbarCouplingFitted": null,
+        "euroStandard": " ",
+        "euVehicleCategory": "n1",
+        "frontAxleTo5thWheelCouplingMax": null,
+        "frontAxleTo5thWheelCouplingMin": null,
+        "frontAxleTo5thWheelMax": null,
+        "frontAxleTo5thWheelMin": null,
+        "functionCode": null,
+        "grossDesignWeight": null,
+        "grossGbWeight": null,
+        "grossKerbWeight": null,
+        "grossLadenWeight": null,
+        "lastUpdatedAt": "2019-06-24T10:26:54.903Z",
+        "make": null,
+        "manufactureYear": null,
+        "maxTrainDesignWeight": null,
+        "maxTrainGbWeight": null,
+        "model": null,
+        "noOfAxles": 2,
+        "notes": null,
+        "ntaNumber": null,
+        "numberOfWheelsDriven": null,
+        "reasonForCreation": null,
+        "recordCompleteness": "complete",
+        "roadFriendly": false,
+        "speedLimiterMrk": null,
+        "statusCode": "current",
+        "tachoExemptMrk": null,
+        "trainDesignWeight": null,
+        "trainGbWeight": null,
+        "tyreUseCode": null,
+        "vehicleClass": {
+          "code": "v",
+          "description": "3 wheelers"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSubclass": [
+          "S"
+        ],
+        "vehicleType": "lgv"
+      }
+    ]
+  },
+  {
+    "systemNumber": "1100315",
+    "vin": "P0123010951215",
+    "partialVin": "951215",
+    "primaryVrm": "LG01SCL",
+    "secondaryVrms": [
+      "AS432TY"
+    ],
+    "techRecord": [
+      {
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": null,
+              "fitmentCode": null,
+              "plyRating": null,
+              "speedCategorySymbol": "a7",
+              "tyreCode": null,
+              "tyreSize": null
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 345,
+              "fitmentCode": "single",
+              "plyRating": "AB",
+              "speedCategorySymbol": "a7",
+              "tyreCode": 5678,
+              "tyreSize": "295/80-22.5"
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "x",
+          "description": null
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "antilockBrakingSystem": true,
+          "brakeCode": "123",
+          "brakeCodeOriginal": "12412",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2332,
+            "secondaryBrakeForceA": 2512,
+            "serviceBrakeForceA": 6424
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 3512,
+            "secondaryBrakeForceB": 2512,
+            "serviceBrakeForceB": 5521
+          },
+          "dataTrBrakeOne": "None",
+          "dataTrBrakeThree": "None",
+          "dataTrBrakeTwo": "None",
+          "dtpNumber": null,
+          "loadSensingValve": true,
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "exhaust"
+        },
+        "conversionRefNo": null,
+        "createdAt": "2019-06-24T10:26:54.903Z",
+        "createdByName": null,
+        "dimensions": {
+          "length": null,
+          "width": null
+        },
+        "drawbarCouplingFitted": null,
+        "euroStandard": " ",
+        "euVehicleCategory": "n1",
+        "frontAxleTo5thWheelCouplingMax": null,
+        "frontAxleTo5thWheelCouplingMin": null,
+        "frontAxleTo5thWheelMax": null,
+        "frontAxleTo5thWheelMin": null,
+        "functionCode": null,
+        "grossDesignWeight": null,
+        "grossGbWeight": null,
+        "grossKerbWeight": null,
+        "grossLadenWeight": null,
+        "lastUpdatedAt": "2019-06-24T10:26:54.903Z",
+        "make": null,
+        "manufactureYear": null,
+        "maxTrainDesignWeight": null,
+        "maxTrainGbWeight": null,
+        "model": null,
+        "noOfAxles": 2,
+        "notes": null,
+        "ntaNumber": null,
+        "numberOfWheelsDriven": null,
+        "reasonForCreation": null,
+        "recordCompleteness": "complete",
+        "roadFriendly": false,
+        "speedLimiterMrk": null,
+        "statusCode": "current",
+        "tachoExemptMrk": null,
+        "trainDesignWeight": null,
+        "trainGbWeight": null,
+        "tyreUseCode": null,
+        "vehicleClass": {
+          "code": "v",
+          "description": "3 wheelers"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSubclass": [
+          "L"
+        ],
+        "vehicleType": "lgv"
+      }
+    ]
+  },
+  {
+    "systemNumber": "1100316",
+    "vin": "P0123010951216",
+    "partialVin": "951216",
+    "primaryVrm": "LG01SCM",
+    "secondaryVrms": [
+      "AS432TY"
+    ],
+    "techRecord": [
+      {
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": null,
+              "fitmentCode": null,
+              "plyRating": null,
+              "speedCategorySymbol": "a7",
+              "tyreCode": null,
+              "tyreSize": null
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 345,
+              "fitmentCode": "single",
+              "plyRating": "AB",
+              "speedCategorySymbol": "a7",
+              "tyreCode": 5678,
+              "tyreSize": "295/80-22.5"
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "x",
+          "description": null
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "antilockBrakingSystem": true,
+          "brakeCode": "123",
+          "brakeCodeOriginal": "12412",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2332,
+            "secondaryBrakeForceA": 2512,
+            "serviceBrakeForceA": 6424
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 3512,
+            "secondaryBrakeForceB": 2512,
+            "serviceBrakeForceB": 5521
+          },
+          "dataTrBrakeOne": "None",
+          "dataTrBrakeThree": "None",
+          "dataTrBrakeTwo": "None",
+          "dtpNumber": null,
+          "loadSensingValve": true,
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "exhaust"
+        },
+        "conversionRefNo": null,
+        "createdAt": "2019-06-24T10:26:54.903Z",
+        "createdByName": null,
+        "dimensions": {
+          "length": null,
+          "width": null
+        },
+        "drawbarCouplingFitted": null,
+        "euroStandard": " ",
+        "euVehicleCategory": "n1",
+        "frontAxleTo5thWheelCouplingMax": null,
+        "frontAxleTo5thWheelCouplingMin": null,
+        "frontAxleTo5thWheelMax": null,
+        "frontAxleTo5thWheelMin": null,
+        "functionCode": null,
+        "grossDesignWeight": null,
+        "grossGbWeight": null,
+        "grossKerbWeight": null,
+        "grossLadenWeight": null,
+        "lastUpdatedAt": "2019-06-24T10:26:54.903Z",
+        "make": null,
+        "manufactureYear": null,
+        "maxTrainDesignWeight": null,
+        "maxTrainGbWeight": null,
+        "model": null,
+        "noOfAxles": 2,
+        "notes": null,
+        "ntaNumber": null,
+        "numberOfWheelsDriven": null,
+        "reasonForCreation": null,
+        "recordCompleteness": "complete",
+        "roadFriendly": false,
+        "speedLimiterMrk": null,
+        "statusCode": "current",
+        "tachoExemptMrk": null,
+        "trainDesignWeight": null,
+        "trainGbWeight": null,
+        "tyreUseCode": null,
+        "vehicleClass": {
+          "code": "v",
+          "description": "3 wheelers"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSubclass": [
+          "M"
+        ],
+        "vehicleType": "lgv"
+      }
+    ]
+  },
+  {
+    "systemNumber": "1100317",
+    "vin": "P0123010951217",
+    "partialVin": "951217",
+    "primaryVrm": "LG01SCP",
+    "secondaryVrms": [
+      "AS432TY"
+    ],
+    "techRecord": [
+      {
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": null,
+              "fitmentCode": null,
+              "plyRating": null,
+              "speedCategorySymbol": "a7",
+              "tyreCode": null,
+              "tyreSize": null
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 345,
+              "fitmentCode": "single",
+              "plyRating": "AB",
+              "speedCategorySymbol": "a7",
+              "tyreCode": 5678,
+              "tyreSize": "295/80-22.5"
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "x",
+          "description": null
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "antilockBrakingSystem": true,
+          "brakeCode": "123",
+          "brakeCodeOriginal": "12412",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2332,
+            "secondaryBrakeForceA": 2512,
+            "serviceBrakeForceA": 6424
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 3512,
+            "secondaryBrakeForceB": 2512,
+            "serviceBrakeForceB": 5521
+          },
+          "dataTrBrakeOne": "None",
+          "dataTrBrakeThree": "None",
+          "dataTrBrakeTwo": "None",
+          "dtpNumber": null,
+          "loadSensingValve": true,
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "exhaust"
+        },
+        "conversionRefNo": null,
+        "createdAt": "2019-06-24T10:26:54.903Z",
+        "createdByName": null,
+        "dimensions": {
+          "length": null,
+          "width": null
+        },
+        "drawbarCouplingFitted": null,
+        "euroStandard": " ",
+        "euVehicleCategory": "n1",
+        "frontAxleTo5thWheelCouplingMax": null,
+        "frontAxleTo5thWheelCouplingMin": null,
+        "frontAxleTo5thWheelMax": null,
+        "frontAxleTo5thWheelMin": null,
+        "functionCode": null,
+        "grossDesignWeight": null,
+        "grossGbWeight": null,
+        "grossKerbWeight": null,
+        "grossLadenWeight": null,
+        "lastUpdatedAt": "2019-06-24T10:26:54.903Z",
+        "make": null,
+        "manufactureYear": null,
+        "maxTrainDesignWeight": null,
+        "maxTrainGbWeight": null,
+        "model": null,
+        "noOfAxles": 2,
+        "notes": null,
+        "ntaNumber": null,
+        "numberOfWheelsDriven": null,
+        "reasonForCreation": null,
+        "recordCompleteness": "complete",
+        "roadFriendly": false,
+        "speedLimiterMrk": null,
+        "statusCode": "current",
+        "tachoExemptMrk": null,
+        "trainDesignWeight": null,
+        "trainGbWeight": null,
+        "tyreUseCode": null,
+        "vehicleClass": {
+          "code": "v",
+          "description": "3 wheelers"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSubclass": [
+          "R"
+        ],
+        "vehicleType": "lgv"
+      }
+    ]
+  },
+  {
+    "systemNumber": "1100318",
+    "vin": "P0123010951218",
+    "partialVin": "951218",
+    "primaryVrm": "LG01SCN",
+    "secondaryVrms": [
+      "AS432TY"
+    ],
+    "techRecord": [
+      {
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": null,
+              "fitmentCode": null,
+              "plyRating": null,
+              "speedCategorySymbol": "a7",
+              "tyreCode": null,
+              "tyreSize": null
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 345,
+              "fitmentCode": "single",
+              "plyRating": "AB",
+              "speedCategorySymbol": "a7",
+              "tyreCode": 5678,
+              "tyreSize": "295/80-22.5"
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "x",
+          "description": null
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "antilockBrakingSystem": true,
+          "brakeCode": "123",
+          "brakeCodeOriginal": "12412",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2332,
+            "secondaryBrakeForceA": 2512,
+            "serviceBrakeForceA": 6424
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 3512,
+            "secondaryBrakeForceB": 2512,
+            "serviceBrakeForceB": 5521
+          },
+          "dataTrBrakeOne": "None",
+          "dataTrBrakeThree": "None",
+          "dataTrBrakeTwo": "None",
+          "dtpNumber": null,
+          "loadSensingValve": true,
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "exhaust"
+        },
+        "conversionRefNo": null,
+        "createdAt": "2019-06-24T10:26:54.903Z",
+        "createdByName": null,
+        "dimensions": {
+          "length": null,
+          "width": null
+        },
+        "drawbarCouplingFitted": null,
+        "euroStandard": " ",
+        "euVehicleCategory": "n1",
+        "frontAxleTo5thWheelCouplingMax": null,
+        "frontAxleTo5thWheelCouplingMin": null,
+        "frontAxleTo5thWheelMax": null,
+        "frontAxleTo5thWheelMin": null,
+        "functionCode": null,
+        "grossDesignWeight": null,
+        "grossGbWeight": null,
+        "grossKerbWeight": null,
+        "grossLadenWeight": null,
+        "lastUpdatedAt": "2019-06-24T10:26:54.903Z",
+        "make": null,
+        "manufactureYear": null,
+        "maxTrainDesignWeight": null,
+        "maxTrainGbWeight": null,
+        "model": null,
+        "noOfAxles": 2,
+        "notes": null,
+        "ntaNumber": null,
+        "numberOfWheelsDriven": null,
+        "reasonForCreation": null,
+        "recordCompleteness": "complete",
+        "roadFriendly": false,
+        "speedLimiterMrk": null,
+        "statusCode": "current",
+        "tachoExemptMrk": null,
+        "trainDesignWeight": null,
+        "trainGbWeight": null,
+        "tyreUseCode": null,
+        "vehicleClass": {
+          "code": "v",
+          "description": "3 wheelers"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSubclass": [
+          "N"
+        ],
+        "vehicleType": "lgv"
+      }
+    ]
+  },
+  {
+    "systemNumber": "1100319",
+    "vin": "P0123010951219",
+    "partialVin": "951219",
+    "primaryVrm": "LG01SCT",
+    "secondaryVrms": [
+      "AS432TY"
+    ],
+    "techRecord": [
+      {
+        "axles": [
+          {
+            "axleNumber": 1,
+            "parkingBrakeMrk": false,
+            "tyres": {
+              "dataTrAxles": null,
+              "fitmentCode": null,
+              "plyRating": null,
+              "speedCategorySymbol": "a7",
+              "tyreCode": null,
+              "tyreSize": null
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          },
+          {
+            "axleNumber": 2,
+            "parkingBrakeMrk": null,
+            "tyres": {
+              "dataTrAxles": 345,
+              "fitmentCode": "single",
+              "plyRating": "AB",
+              "speedCategorySymbol": "a7",
+              "tyreCode": 5678,
+              "tyreSize": "295/80-22.5"
+            },
+            "weights": {
+              "designWeight": null,
+              "gbWeight": null
+            }
+          }
+        ],
+        "bodyType": {
+          "code": "x",
+          "description": null
+        },
+        "brakeCode": "178202",
+        "brakes": {
+          "antilockBrakingSystem": true,
+          "brakeCode": "123",
+          "brakeCodeOriginal": "12412",
+          "brakeForceWheelsNotLocked": {
+            "parkingBrakeForceA": 2332,
+            "secondaryBrakeForceA": 2512,
+            "serviceBrakeForceA": 6424
+          },
+          "brakeForceWheelsUpToHalfLocked": {
+            "parkingBrakeForceB": 3512,
+            "secondaryBrakeForceB": 2512,
+            "serviceBrakeForceB": 5521
+          },
+          "dataTrBrakeOne": "None",
+          "dataTrBrakeThree": "None",
+          "dataTrBrakeTwo": "None",
+          "dtpNumber": null,
+          "loadSensingValve": true,
+          "retarderBrakeOne": "electric",
+          "retarderBrakeTwo": "exhaust"
+        },
+        "conversionRefNo": null,
+        "createdAt": "2019-06-24T10:26:54.903Z",
+        "createdByName": null,
+        "dimensions": {
+          "length": null,
+          "width": null
+        },
+        "drawbarCouplingFitted": null,
+        "euroStandard": " ",
+        "euVehicleCategory": "n1",
+        "frontAxleTo5thWheelCouplingMax": null,
+        "frontAxleTo5thWheelCouplingMin": null,
+        "frontAxleTo5thWheelMax": null,
+        "frontAxleTo5thWheelMin": null,
+        "functionCode": null,
+        "grossDesignWeight": null,
+        "grossGbWeight": null,
+        "grossKerbWeight": null,
+        "grossLadenWeight": null,
+        "lastUpdatedAt": "2019-06-24T10:26:54.903Z",
+        "make": null,
+        "manufactureYear": null,
+        "maxTrainDesignWeight": null,
+        "maxTrainGbWeight": null,
+        "model": null,
+        "noOfAxles": 2,
+        "notes": null,
+        "ntaNumber": null,
+        "numberOfWheelsDriven": null,
+        "reasonForCreation": null,
+        "recordCompleteness": "complete",
+        "roadFriendly": false,
+        "speedLimiterMrk": null,
+        "statusCode": "current",
+        "tachoExemptMrk": null,
+        "trainDesignWeight": null,
+        "trainGbWeight": null,
+        "tyreUseCode": null,
+        "vehicleClass": {
+          "code": "v",
+          "description": "3 wheelers"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSubclass": [
+          "T"
+        ],
+        "vehicleType": "lgv"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5978320",
+    "vin": "12340SBW200910801",
+    "partialVin": "910801",
+    "primaryVrm": "MC001VC",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T14:54:32.000000Z",
+        "euVehicleCategory": null,
+        "lastUpdatedAt": "2023-02-07T20:56:34.000000Z",
+        "make": "PEDIBAL",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "Any",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "1",
+          "description": "motorbikes up to 200cc"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+        ],
+        "vehicleType": "motorcycle"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5978321",
+    "vin": "12340SBW200910802",
+    "partialVin": "910802",
+    "primaryVrm": "MC012VC",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T14:54:32.000000Z",
+        "euVehicleCategory": null,
+        "lastUpdatedAt": "2023-02-07T20:56:34.000000Z",
+        "make": "PEDIBAL",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "2",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "1",
+          "description": "motorbikes up to 200cc"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+        ],
+        "vehicleType": "motorcycle"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5978322",
+    "vin": "12340SBW200910803",
+    "partialVin": "910803",
+    "primaryVrm": "MC022VC",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T14:54:32.000000Z",
+        "euVehicleCategory": null,
+        "lastUpdatedAt": "2023-02-07T20:56:34.000000Z",
+        "make": "PEDIBAL",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "2",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "2",
+          "description": "motorbikes up to 200cc"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+        ],
+        "vehicleType": "motorcycle"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5978323",
+    "vin": "12340SBW200910804",
+    "partialVin": "910804",
+    "primaryVrm": "MC033VC",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T14:54:32.000000Z",
+        "euVehicleCategory": null,
+        "lastUpdatedAt": "2023-02-07T20:56:34.000000Z",
+        "make": "PEDIBAL",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "3",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "3",
+          "description": "motorbikes up to 200cc"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+        ],
+        "vehicleType": "motorcycle"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5978324",
+    "vin": "12340SBW200910805",
+    "partialVin": "910805",
+    "primaryVrm": "MC043VC",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T14:54:32.000000Z",
+        "euVehicleCategory": null,
+        "lastUpdatedAt": "2023-02-07T20:56:34.000000Z",
+        "make": "PEDIBAL",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "3",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "4",
+          "description": "motorbikes up to 200cc"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+        ],
+        "vehicleType": "motorcycle"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5978325",
+    "vin": "12340SBW200910806",
+    "partialVin": "910806",
+    "primaryVrm": "MC044VC",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T14:54:32.000000Z",
+        "euVehicleCategory": null,
+        "lastUpdatedAt": "2023-02-07T20:56:34.000000Z",
+        "make": "PEDIBAL",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "4",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "4",
+          "description": "motorbikes up to 200cc"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+        ],
+        "vehicleType": "motorcycle"
+      }
+    ]
   }
 ]

--- a/tests/resources/technical-records.json
+++ b/tests/resources/technical-records.json
@@ -40369,5 +40369,117 @@
         "vehicleType": "hgv"
       }
     ]
+  },
+  {
+    "systemNumber": "5917413",
+    "vin": "SHB1HT07500123456",
+    "partialVin": "123456",
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2022-09-26T16:58:05.000000Z",
+        "euVehicleCategory": "o1",
+        "lastUpdatedAt": "2022-09-27T00:55:45.000000Z",
+        "make": "HAZLEWOOD",
+        "manufactureYear": 2022,
+        "model": " ",
+        "noOfAxles": 1,
+        "numberOfWheelsDriven": null,
+        "reasonForCreation": " ",
+        "recordCompleteness": "testable",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "t",
+          "description": "trailer"
+        },
+        "vehicleConfiguration": "semi-trailer",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+        ],
+        "vehicleType": "trl"
+      }
+    ],
+    "trailerId": "123456T"
+  },
+  {
+    "systemNumber": "5978167",
+    "vin": "12340SBW200910880",
+    "partialVin": "910880",
+    "primaryVrm": "995243Z",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T14:54:32.000000Z",
+        "euVehicleCategory": null,
+        "lastUpdatedAt": "2023-02-07T20:56:34.000000Z",
+        "make": "PEDIBAL",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "1",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "1",
+          "description": "motorbikes up to 200cc"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+        ],
+        "vehicleType": "motorcycle"
+      }
+    ]
+  },
+  {
+    "systemNumber": "5976221",
+    "vin": "AA11100851",
+    "partialVin": "100851",
+    "primaryVrm": "991234Z",
+    "secondaryVrms": [
+      " "
+    ],
+    "techRecord": [
+      {
+        "bodyType": {
+          "code": null,
+          "description": null
+        },
+        "createdAt": "2023-02-07T10:39:47.000000Z",
+        "euVehicleCategory": "m1",
+        "lastUpdatedAt": "2023-02-09T20:45:45.000000Z",
+        "make": "HONDA",
+        "manufactureYear": null,
+        "model": " ",
+        "noOfAxles": 0,
+        "numberOfWheelsDriven": "2",
+        "reasonForCreation": " ",
+        "recordCompleteness": "complete",
+        "regnDate": null,
+        "statusCode": "current",
+        "vehicleClass": {
+          "code": "4",
+          "description": "MOT class 4"
+        },
+        "vehicleConfiguration": "other",
+        "vehicleSize": null,
+        "vehicleSubclass": [
+          "r"
+        ],
+        "vehicleType": "car"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
CB2-7330:

when archiving a tech record the vrm's are stored as historic VRM's on the record in the interest of displaying them as they were when the record was archived. 