### PR TITLE
feat(VTA-468): update rules for eu category

### DIFF
--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -34,10 +34,9 @@ export enum HTTPRESPONSE {
     NO_STATUS_UPDATE_REQUIRED = "No status update required",
     NO_EU_VEHICLE_CATEGORY_UPDATE_REQUIRED = "No EU vehicle category update required",
     INVALID_EU_VEHICLE_CATEGORY = "Invalid EU vehicle category",
-    EU_VEHICLE_CATEGORY_MORE_THAN_ONE_TECH_RECORD = "The vehicle has more than one non archived Tech record.",
+    EU_VEHICLE_CATEGORY_MORE_THAN_TWO_TECH_RECORDS = "The vehicle has more than two non archived Tech records.",
     TECHINICAL_RECORD_CREATED = "Technical Record created",
-    MISSING_PARAMETERS = "Missing parameter value.",
-    VIN_UPDATED = "VIN updated"
+    MISSING_PARAMETERS = "Missing parameter value."
 }
 
 export enum STATUS {

--- a/src/assets/Enums.ts
+++ b/src/assets/Enums.ts
@@ -36,7 +36,8 @@ export enum HTTPRESPONSE {
     INVALID_EU_VEHICLE_CATEGORY = "Invalid EU vehicle category",
     EU_VEHICLE_CATEGORY_MORE_THAN_TWO_TECH_RECORDS = "The vehicle has more than two non archived Tech records.",
     TECHINICAL_RECORD_CREATED = "Technical Record created",
-    MISSING_PARAMETERS = "Missing parameter value."
+    MISSING_PARAMETERS = "Missing parameter value.",
+    VIN_UPDATED = "VIN updated"
 }
 
 export enum STATUS {

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -364,7 +364,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
       techRecord.statusCode = enums.STATUS.ARCHIVED;
       newTechRecord.euVehicleCategory = newEuVehicleCategory;
       newTechRecord.statusCode = statusCode;
-      newTechRecord.reasonForCreation = 'Update to Eu Vehicle Category';
+      newTechRecord.reasonForCreation = 'Update to EU Vehicle Category';
       this.auditHandler.setAuditDetails(newTechRecord, nonArchivedTechRecord[0],msUserDetails);
       vehicle.techRecord.push(newTechRecord);
     });

--- a/src/domain/Processors/VehicleProcessor.ts
+++ b/src/domain/Processors/VehicleProcessor.ts
@@ -364,6 +364,7 @@ export abstract class VehicleProcessor<T extends Vehicle> {
       techRecord.statusCode = enums.STATUS.ARCHIVED;
       newTechRecord.euVehicleCategory = newEuVehicleCategory;
       newTechRecord.statusCode = statusCode;
+      newTechRecord.reasonForCreation = 'Update to Eu Vehicle Category';
       this.auditHandler.setAuditDetails(newTechRecord, nonArchivedTechRecord[0],msUserDetails);
       vehicle.techRecord.push(newTechRecord);
     });

--- a/tests/unit/TechRecordsService.unitTest.ts
+++ b/tests/unit/TechRecordsService.unitTest.ts
@@ -933,11 +933,35 @@ describe("updateEuVehicleCategory", () => {
     });
   });
 
-  context("when finding more than one non-archived tech-records", () => {
-    it("should throw error More than one non-archived records found", async () => {
+  context("when updating a euVehicleCategory for an existing vehicle where the value is not null on both non archived tech records", () => {
+    it("should throw error No EU vehicle category update required", async () => {
       const systemNumber = "10000001";
       const record: any = cloneDeep(records[0]);
       const techRecord = record.techRecord[0];
+      record.techRecord.push(techRecord);
+      const MockDAO = jest.fn().mockImplementation(() => {
+        return {
+          getBySearchTerm: () => {
+            return Promise.resolve([record]);
+          }
+        };
+      });
+      expect.assertions(2);
+      const {msUser, msOid } = msUserDetails;
+      const mockDAO = new MockDAO();
+      const techRecordsService = new TechRecordsService(mockDAO);
+      const response: HTTPResponse | HTTPError = await techRecordsService.updateEuVehicleCategory(systemNumber, EU_VEHICLE_CATEGORY.M1, msOid, msUser);
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toEqual(`"${HTTPRESPONSE.NO_EU_VEHICLE_CATEGORY_UPDATE_REQUIRED}"`);
+    });
+  });
+
+  context("when finding more than two non-archived tech-records", () => {
+    it("should throw error More than two non-archived records found", async () => {
+      const systemNumber = "10000001";
+      const record: any = cloneDeep(records[0]);
+      const techRecord = record.techRecord[0];
+      record.techRecord.push(techRecord);
       record.techRecord.push(techRecord);
       const MockDAO = jest.fn().mockImplementation(() => {
         return {
@@ -955,7 +979,7 @@ describe("updateEuVehicleCategory", () => {
       } catch (error) {
         expect(error.statusCode).toEqual(400);
         // FIXME: from array to string
-        expect(error.body.errors).toContain(HTTPRESPONSE.EU_VEHICLE_CATEGORY_MORE_THAN_ONE_TECH_RECORD);
+        expect(error.body.errors).toContain(HTTPRESPONSE.EU_VEHICLE_CATEGORY_MORE_THAN_TWO_TECH_RECORDS);
       }
     });
   });


### PR DESCRIPTION
## Update Rules for EU Category

This is to resolve the following issues:
- Where an error is thrown when trying to update the eu vehicle category where there is more than one
- Allow the eu vehicle category to be updated for more than one technical record
- Change the reasonForCreation field to say: Update to EU Vehicle Category for all tech records

[VTA-468](https://dvsa.atlassian.net/browse/VTA-468)
[VTA-531](https://dvsa.atlassian.net/browse/VTA-531)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
