### PR TITLE
fix(cb2-7668): unable to update to previously used vin

### DIFF
--- a/src/functions/updateVin.ts
+++ b/src/functions/updateVin.ts
@@ -39,21 +39,25 @@ const updateVin = async (event: any) => {
 
     validateVins(activeVehicle.vin, newVin);
 
-    const now = new Date().toISOString();
+    // In case we update to an existing vin, we have to extract the archived records on that vin to save them back in
+    const previousTechRecordsOnNewVin =
+      vehicles.find((vehicle) => vehicle.vin === newVin)?.techRecord ?? [];
 
     const { oldVehicle, newVehicle } = techRecordsService.updateVin(
       activeVehicle,
       newVin,
       msUser,
-      msOid
+      msOid,
+      previousTechRecordsOnNewVin
     );
 
     await techRecordsDAO.updateVin(newVehicle, oldVehicle);
 
     return new HTTPResponse(200, HTTPRESPONSE.VIN_UPDATED);
   } catch (error) {
+    console.log(error);
     if (error instanceof HTTPError) {
-      return error;
+      return new HTTPResponse(error.statusCode, error.body);
     } else {
       return new HTTPResponse(500, HTTPRESPONSE.INTERNAL_SERVER_ERROR);
     }

--- a/src/models/TechRecordsDAO.ts
+++ b/src/models/TechRecordsDAO.ts
@@ -63,7 +63,10 @@ class TechRecordsDAO {
     query.IndexName = this.CriteriaIndexMap[searchCriteria];
   }
 
-  public async getBySearchTerm(searchTerm: string, searchCriteria: ISearchCriteria) {
+  public async getBySearchTerm(
+    searchTerm: string,
+    searchCriteria: ISearchCriteria
+  ) {
     searchTerm = searchTerm.toUpperCase();
     const query: QueryInput = {
       TableName: this.tableName,
@@ -87,7 +90,7 @@ class TechRecordsDAO {
 
     console.log("Query Params for getBySearchTerm ", query);
     try {
-      return  await this.queryAllData(query);
+      return await this.queryAllData(query);
     } catch (err) {
       console.log("Error in queryAllData ", err);
       throw err;
@@ -247,19 +250,13 @@ class TechRecordsDAO {
     };
   }
 
-  public updateVin<T extends Vehicle>(newVehicle: any, oldVehicle: T) {
+  public updateVin<T extends Vehicle>(newVehicle: T, oldVehicle: T) {
     const transactionParams = {
       TransactItems: [
         {
           Put: {
             TableName: this.tableName,
             Item: newVehicle,
-            ConditionExpression:
-              "vin <> :vin AND systemNumber <> :systemNumber",
-            ExpressionAttributeValues: {
-              ":vin": newVehicle.vin,
-              ":systemNumber": newVehicle.systemNumber,
-            },
           },
         },
         {

--- a/src/services/TechRecordsService.ts
+++ b/src/services/TechRecordsService.ts
@@ -16,6 +16,7 @@ import { TechRecordStatusHandler } from "../handlers/TechRecordStatusHandler";
 import HTTPError from "../models/HTTPError";
 import HTTPResponse from "../models/HTTPResponse";
 import TechRecordsDAO from "../models/TechRecordsDAO";
+import { populatePartialVin } from "../utils/validations";
 
 /**
  * Fetches the entire list of Technical Records from the database.
@@ -195,7 +196,8 @@ class TechRecordsService {
     vehicle: Vehicle,
     newVin: string,
     msUser: string,
-    msOid: string
+    msOid: string,
+    previousTechRecordsOnNewVin: TechRecord[]
   ) {
     const vehicleClone = cloneDeep(vehicle);
 
@@ -255,6 +257,9 @@ class TechRecordsService {
         lastUpdatedByName: msUser,
       });
     }
+
+    newVehicle.partialVin = populatePartialVin(newVin);
+    newVehicle.techRecord.push(...previousTechRecordsOnNewVin);
 
     return { oldVehicle, newVehicle };
   }

--- a/tests/unit/TechRecordsService.unitTest.ts
+++ b/tests/unit/TechRecordsService.unitTest.ts
@@ -1186,7 +1186,7 @@ describe("updateTechRecordStatus", () => {
       });
       const mockDAO = new MockDAO();
       const techRecordsService = new TechRecordsService(mockDAO);
-      const result = techRecordsService.updateVin(vehicle, newVin, "foo", "bar");
+      const result = techRecordsService.updateVin(vehicle, newVin, "foo", "bar", []);
       it("returns two vehicle records (oldVehicle, newVehicle)", () => {
         expect(result.oldVehicle).toBeDefined();
         expect(result.newVehicle).toBeDefined();
@@ -1233,7 +1233,7 @@ describe("updateTechRecordStatus", () => {
       });
       const mockDAO = new MockDAO();
       const techRecordsService = new TechRecordsService(mockDAO);
-      const result = techRecordsService.updateVin(vehicle, newVin, "foo", "bar");
+      const result = techRecordsService.updateVin(vehicle, newVin, "foo", "bar", []);
       it("returns two vehicle records (oldVehicle, newVehicle)", () => {
         expect(result.oldVehicle).toBeDefined();
         expect(result.newVehicle).toBeDefined();
@@ -1290,7 +1290,8 @@ describe("updateTechRecordStatus", () => {
     });
     const mockDAO = new MockDAO();
     const techRecordsService = new TechRecordsService(mockDAO);
-    const result = techRecordsService.updateVin(vehicle, newVin, "foo", "bar");
+    const mockOriginalArchivedRecordsOnVin: any[] = [{reasonForCreation: "testing"}, {reasonForCreation: "Another test"}];
+    const result = techRecordsService.updateVin(vehicle, newVin, "foo", "bar", mockOriginalArchivedRecordsOnVin);
     it("returns two vehicle records (oldVehicle, newVehicle)", () => {
       expect(result.oldVehicle).toBeDefined();
       expect(result.newVehicle).toBeDefined();
@@ -1305,8 +1306,8 @@ describe("updateTechRecordStatus", () => {
       expect(result.oldVehicle.techRecord[0].statusCode).toEqual("archived");
       expect(result.oldVehicle.techRecord[1].statusCode).toEqual("archived");
     });
-    it("newVehicle has a techRecord.length of 1", () => {
-      expect(result.newVehicle.techRecord.length).toEqual(1);
+    it("newVehicle has a techRecord.length of 3", () => {
+      expect(result.newVehicle.techRecord.length).toEqual(3);
     });
     it("newVehicle techRecord has a status of Provisional", () => {
       expect(result.newVehicle.techRecord[0].statusCode).toEqual("provisional");
@@ -1316,6 +1317,13 @@ describe("updateTechRecordStatus", () => {
     });
     it("newVehicle record is the correct record and its other data is intact", () => {
       expect(result.newVehicle.techRecord[0].recordCompleteness).toEqual("complete");
+    });
+    it("newVehicle record should have the previous archived tech records", () => {
+      expect(result.newVehicle.techRecord).toEqual(expect.arrayContaining(mockOriginalArchivedRecordsOnVin));
+    });
+    it("newVehicle record should an updated partial vin", () => {
+      expect(result.newVehicle.partialVin).toEqual(newVin);
+      expect(result.newVehicle.partialVin).not.toEqual(result.oldVehicle.partialVin);
     });
   });
 });

--- a/tests/unit/domain/updateVin.unitTest.ts
+++ b/tests/unit/domain/updateVin.unitTest.ts
@@ -61,9 +61,11 @@ describe("updateVin", () => {
         const response = await updateVin(event);
 
         expect(response.statusCode).toBe(500);
-        expect(response.body).toEqual({
-          errors: ["Failed to uniquely identify record"],
-        });
+        expect(response.body).toEqual(
+          JSON.stringify({
+            errors: ["Failed to uniquely identify record"],
+          })
+        );
       });
     });
 
@@ -85,7 +87,7 @@ describe("updateVin", () => {
         const response = await updateVin(event);
 
         expect(response.statusCode).toBe(500);
-        expect(response.body).toEqual("\"Internal Server Error\"");
+        expect(response.body).toEqual('"Internal Server Error"');
       });
     });
   });


### PR DESCRIPTION
## Ability to update to a previously used vin

- Adds ability to update to previously used vin
- Fixes the issue where the partial vin was not being updated
- Fixed an issue where validation errors were not being properly sent over locally (postman) (and maybe in AWS?)
[CB2-7668](https://dvsa.atlassian.net/browse/CB2-7668)

## Checklist

- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
