### PR TITLE
fix(cb2-6641): allow notes on small vehicles

### DIFF
--- a/src/utils/validations/CarValidations.ts
+++ b/src/utils/validations/CarValidations.ts
@@ -13,5 +13,6 @@ export const carValidation = commonSchemaLgvCarSmallTrlMotorcycle.keys({
       otherwise: Joi.object().forbidden()
     }),
     description: Joi.string().valid(...VEHICLE_CLASS_DESCRIPTION)
-  }).optional().allow(null)
+  }).optional().allow(null),
+  notes: Joi.string().optional().allow(null, "")
 });

--- a/src/utils/validations/LgvValidations.ts
+++ b/src/utils/validations/LgvValidations.ts
@@ -13,5 +13,6 @@ export const lgvValidation = commonSchemaLgvCarSmallTrlMotorcycle.keys({
       otherwise: Joi.object().forbidden()
     }),
     description: Joi.string().valid(...VEHICLE_CLASS_DESCRIPTION)
-  }).optional().allow(null)
+  }).optional().allow(null),
+  notes: Joi.string().optional().allow(null, "")
 });

--- a/src/utils/validations/MotorcycleValidations.ts
+++ b/src/utils/validations/MotorcycleValidations.ts
@@ -13,5 +13,6 @@ export const motorcycleValidation = commonSchemaLgvCarSmallTrlMotorcycle.keys({
       otherwise: Joi.object().forbidden()
     }),
     description: Joi.string().valid(...VEHICLE_CLASS_DESCRIPTION)
-  })
+  }),
+  notes: Joi.string().optional().allow(null, "")
 });

--- a/src/utils/validations/SmallTrailerValidation.ts
+++ b/src/utils/validations/SmallTrailerValidation.ts
@@ -14,5 +14,5 @@ export const smallTrailerValidation = commonSchemaLgvCarSmallTrlMotorcycle.keys(
     }),
     description: Joi.string().valid(...VEHICLE_CLASS_DESCRIPTION)
   }).optional().allow(null),
-  notes: Joi.string().optional().allow(null, ""),
+  notes: Joi.string().optional().allow(null, "")
 });


### PR DESCRIPTION
## Amend a light vehicle Tech Record

- Add validation to cover the notes field for light vehicles.

[CB2-6641](https://dvsa.atlassian.net/browse/CB2-6641)