### PR TITLE
fix(cb2-7727): enable generating trailer ids for small trailers and update their completeness calcs

### DIFF
--- a/@Types/TechRecords.d.ts
+++ b/@Types/TechRecords.d.ts
@@ -33,7 +33,7 @@ export interface Trailer extends TrailerIdentifer {
   techRecord: TrlTechRecord[];
 }
 
-export interface SmallTrailer extends Vehicle {
+export interface SmallTrailer extends TrailerIdentifer {
   techRecord: TrlTechRecord[];
 }
 

--- a/src/domain/Processors/SmallTrailerProcessor.ts
+++ b/src/domain/Processors/SmallTrailerProcessor.ts
@@ -11,6 +11,12 @@ export class SmallTrailerProcessor extends VehicleProcessor<SmallTrailer> {
 
   protected async setNumberKey(): Promise<void> {
     this.vehicle.systemNumber = await this.numberGenerator.generateSystemNumber();
+    
+    if(!this.vehicle.trailerId) {
+      const newTrailerId = await this.numberGenerator.generateTrailerId();
+      this.vehicle.trailerId = newTrailerId;
+      this.vehicle.primaryVrm = newTrailerId;
+    }
   }
 
   protected validateTechRecordFields(newVehicle: CarLgvTechRecord): string[] {

--- a/src/utils/record-completeness/ComputeRecordCompleteness.ts
+++ b/src/utils/record-completeness/ComputeRecordCompleteness.ts
@@ -1,6 +1,6 @@
 import { ValidationResult, ObjectSchema } from '@hapi/joi';
 import { Vehicle, Trailer } from '../../../@Types/TechRecords';
-import { ERRORS, RECORD_COMPLETENESS_ENUM, VEHICLE_TYPE } from '../../assets';
+import { ERRORS, EU_VEHICLE_CATEGORY, RECORD_COMPLETENESS_ENUM, VEHICLE_TYPE } from '../../assets';
 import HTTPError from '../../models/HTTPError';
 import {
   trlCoreMandatoryVehicleAttributes,
@@ -76,7 +76,9 @@ function validateMandatoryTechRecordAttributes(vehicle: Vehicle) {
     throw new HTTPError(400, ERRORS.VEHICLE_TYPE_ERROR);
   }
 
-  const nonCoreMandatorySchema: ObjectSchema | undefined = nonCoreMandatorySchemaMap.get(vehicleType);
+  const nonCoreMandatorySchema: ObjectSchema | undefined = techRecord.euVehicleCategory !== EU_VEHICLE_CATEGORY.O1
+    ? nonCoreMandatorySchemaMap.get(vehicleType)
+    : undefined;
 
   return {
     coreValidationResult: coreMandatorySchema.validate(techRecord, {stripUnknown: true}),

--- a/tests/features/step_definitions/10213.ACs.feature.steps.intTest.ts
+++ b/tests/features/step_definitions/10213.ACs.feature.steps.intTest.ts
@@ -4,6 +4,7 @@ import path from "path";
 import mockData from "../../resources/technical-records.json";
 import { emptyDatabase, populateDatabase } from "../../util/dbOperations";
 import { cloneDeep } from "lodash";
+import { EU_VEHICLE_CATEGORY } from '../../../src/assets';
 
 const url = "http://localhost:3005/";
 const request = supertest(url);
@@ -119,6 +120,7 @@ defineFeature(feature, (test) => {
       requestUrlGET = `vehicles/${postPayload.vin}/tech-records`;
     });
     and('I have completed the "body type description" field', () => {
+      postPayload.techRecord[0].euVehicleCategory = EU_VEHICLE_CATEGORY.O2;
       postPayload.techRecord[0].bodyType = {
         description: "skeletal",
       };

--- a/tests/unit/ComputeRecordCompleteness.unitTest.ts
+++ b/tests/unit/ComputeRecordCompleteness.unitTest.ts
@@ -2,7 +2,7 @@ import {cloneDeep} from "lodash";
 import mockData from "../resources/technical-records.json";
 import {computeRecordCompleteness} from "../../src/utils/record-completeness/ComputeRecordCompleteness";
 import HTTPError from "../../src/models/HTTPError";
-import {ERRORS, RECORD_COMPLETENESS_ENUM} from "../../src/assets/Enums";
+import {ERRORS, EU_VEHICLE_CATEGORY, RECORD_COMPLETENESS_ENUM} from "../../src/assets/Enums";
 
 describe("Record completeness for systemNumber and Vin", () => {
   let techRecord: any;
@@ -148,6 +148,7 @@ describe("Compute Record Completeness", () => {
       it("should return TESTABLE if all core mandatory are completed and one of the non-core mandatory attributes is missing", () => {
         const record: any = cloneDeep(mockData[126]);
         delete record.techRecord[0].dimensions.length;
+        record.techRecord[0].euVehicleCategory = EU_VEHICLE_CATEGORY.O2;
         const recordCompleteness = computeRecordCompleteness(record);
         expect(recordCompleteness).toEqual(RECORD_COMPLETENESS_ENUM.TESTABLE);
       });


### PR DESCRIPTION
## Manage small trailers in VTM

- Generate IDs for small trailers.
- Update the record completeness schema for small trailers' non-mandatory fields.

[CB2-7727](https://dvsa.atlassian.net/browse/CB2-7727)