### PR TITLE
fix(cb2-7946): do not save trailer ids as primary vrms

### DIFF
--- a/src/domain/Processors/SmallTrailerProcessor.ts
+++ b/src/domain/Processors/SmallTrailerProcessor.ts
@@ -15,7 +15,6 @@ export class SmallTrailerProcessor extends VehicleProcessor<SmallTrailer> {
     if (!this.vehicle.trailerId) {
       const tNumber = await this.numberGenerator.generateTNumber();
       this.vehicle.trailerId = tNumber;
-      this.vehicle.primaryVrm = tNumber;
     }
   }
 

--- a/src/domain/Processors/TrailerProcessor.ts
+++ b/src/domain/Processors/TrailerProcessor.ts
@@ -49,7 +49,6 @@ export class TrailerProcessor extends VehicleProcessor<Trailer> {
     if(!this.vehicle.trailerId) {
       const newTrailerId = await this.numberGenerator.generateTrailerId();
       this.vehicle.trailerId = newTrailerId;
-      this.vehicle.primaryVrm = newTrailerId;
     }
   }
 


### PR DESCRIPTION
## Small trailers saving a primary VRM

[CB2-7946](https://dvsa.atlassian.net/browse/CB2-7946)