### PR TITLE
feat(VTA-1492): UI Auto Update Seed Data

### DIFF
--- a/tests/resources/technical-records.json
+++ b/tests/resources/technical-records.json
@@ -43353,7 +43353,7 @@
     "vin": "T12111222"
   },
   {
-    "systemNumber": "10000045",
+    "systemNumber": "90000001",
     "vin": "AUTOQAPSV00000006",
     "partialVin": "000006",
     "primaryVrm": "QA06PSV",
@@ -43638,7 +43638,7 @@
     ]
   },
   {
-    "systemNumber": "10000074",
+    "systemNumber": "90000002",
     "vin": "AUTOQAPSV00000007",
     "partialVin": "000007",
     "primaryVrm": "QA07PSV",
@@ -43887,7 +43887,7 @@
     ]
   },
   {
-    "systemNumber": "10000075",
+    "systemNumber": "90000003",
     "vin": "AUTOQAPSV00000008",
     "partialVin": "000008",
     "primaryVrm": "QA08PSV",
@@ -44136,7 +44136,7 @@
     ]
   },
   {
-    "systemNumber": "10000096",
+    "systemNumber": "90000004",
     "vin": "AUTOQAPSV00000009",
     "partialVin": "000009",
     "primaryVrm": "QA09PSV",
@@ -44385,7 +44385,7 @@
     ]
   },
   {
-    "systemNumber": "10000098",
+    "systemNumber": "90000005",
     "vin": "AUTOQAPSV00000010",
     "partialVin": "000010",
     "primaryVrm": "QA10PSV",
@@ -44634,7 +44634,7 @@
     ]
   },
   {
-    "systemNumber": "10000107",
+    "systemNumber": "90000006",
     "vin": "AUTOQAHGV00000006",
     "partialVin": "000006",
     "primaryVrm": "QA06HGV",
@@ -44871,7 +44871,7 @@
     ]
   },
   {
-    "systemNumber": "10000119",
+    "systemNumber": "90000007",
     "vin": "AUTOQAHGV00000007",
     "partialVin": "000007",
     "primaryVrm": "QA07HGV",
@@ -45108,7 +45108,7 @@
     ]
   },
   {
-    "systemNumber": "10000116",
+    "systemNumber": "90000008",
     "vin": "AUTOQAHGV00000008",
     "partialVin": "000008",
     "primaryVrm": "QA08HGV",
@@ -45345,7 +45345,7 @@
     ]
   },
   {
-    "systemNumber": "10000117",
+    "systemNumber": "90000009",
     "vin": "AUTOQAHGV00000009",
     "partialVin": "000009",
     "primaryVrm": "QA09HGV",
@@ -45622,7 +45622,7 @@
     ]
   },
   {
-    "systemNumber": "10000118",
+    "systemNumber": "90000010",
     "vin": "AUTOQAHGV00000010",
     "partialVin": "000010",
     "primaryVrm": "QA10HGV",
@@ -45939,7 +45939,7 @@
     ]
   },
   {
-    "systemNumber": "10000120",
+    "systemNumber": "90000011",
     "vin": "AUTOQATRA000000006",
     "partialVin": "000006",
     "techRecord": [
@@ -46157,7 +46157,7 @@
     "trailerId": "Q111116"
   },
   {
-    "systemNumber": "10000038",
+    "systemNumber": "90000012",
     "vin": "AUTOQATRA000000007",
     "partialVin": "000007",
     "techRecord": [
@@ -46415,7 +46415,7 @@
     "trailerId": "Q111117"
   },
   {
-    "systemNumber": "10000039",
+    "systemNumber": "90000013",
     "vin": "AUTOQATRA000000008",
     "partialVin": "000008",
     "techRecord": [
@@ -46633,7 +46633,7 @@
     "trailerId": "Q111118"
   },
   {
-    "systemNumber": "10000040",
+    "systemNumber": "90000014",
     "vin": "AUTOQATRA000000009",
     "partialVin": "000009",
     "techRecord": [
@@ -46893,7 +46893,7 @@
     "trailerId": "Q111119"
   },
   {
-    "systemNumber": "10000052",
+    "systemNumber": "90000015",
     "vin": "AUTOQATRA000000010",
     "partialVin": "000010",
     "techRecord": [
@@ -47195,7 +47195,7 @@
     "trailerId": "Q111120"
   },
   {
-    "systemNumber": "10000086",
+    "systemNumber": "90000016",
     "vin": "AUTOQACAR00000001",
     "partialVin": "000001",
     "primaryVrm": "QA01CAR",
@@ -47233,7 +47233,7 @@
     ]
   },
   {
-    "systemNumber": "10000087",
+    "systemNumber": "90000017",
     "vin": "AUTOQACAR00000002",
     "partialVin": "000002",
     "primaryVrm": "QA02CAR",
@@ -47271,7 +47271,7 @@
     ]
   },
   {
-    "systemNumber": "10000088",
+    "systemNumber": "90000018",
     "vin": "AUTOQACAR00000003",
     "partialVin": "000003",
     "primaryVrm": "QA03CAR",
@@ -47309,7 +47309,7 @@
     ]
   },
   {
-    "systemNumber": "10000089",
+    "systemNumber": "90000019",
     "vin": "AUTOQALGV00000001",
     "partialVin": "000001",
     "primaryVrm": "QA01LGV",
@@ -47347,7 +47347,7 @@
     ]
   },
   {
-    "systemNumber": "10000090",
+    "systemNumber": "90000020",
     "vin": "AUTOQALGV00000002",
     "partialVin": "000002",
     "primaryVrm": "QA02LGV",
@@ -47385,7 +47385,7 @@
     ]
   },
   {
-    "systemNumber": "10000091",
+    "systemNumber": "90000021",
     "vin": "AUTOQALGV00000003",
     "partialVin": "000003",
     "primaryVrm": "QA03LGV",
@@ -47423,7 +47423,7 @@
     ]
   },
   {
-    "systemNumber": "10000094",
+    "systemNumber": "90000022",
     "vin": "AUTOQASTRL0000001",
     "partialVin": "000001",
     "techRecord": [
@@ -47464,7 +47464,7 @@
     "trailerId": "020003T"
   },
   {
-    "systemNumber": "10000095",
+    "systemNumber": "90000023",
     "vin": "AUTOQASTRL0000002",
     "partialVin": "000002",
     "techRecord": [
@@ -47505,7 +47505,7 @@
     "trailerId": "020004T"
   },
   {
-    "systemNumber": "10000096",
+    "systemNumber": "90000024",
     "vin": "AUTOQASTRL0000003",
     "partialVin": "000003",
     "techRecord": [
@@ -47546,7 +47546,7 @@
     "trailerId": "020005T"
   },
   {
-    "systemNumber": "10000097",
+    "systemNumber": "90000025",
     "vin": "AUTOQASTRL0000004",
     "partialVin": "000004",
     "techRecord": [
@@ -47587,7 +47587,7 @@
     "trailerId": "020006T"
   },
   {
-    "systemNumber": "10000098",
+    "systemNumber": "90000026",
     "vin": "AUTOQAMCYCLE00001",
     "partialVin": "E00001",
     "primaryVrm": "QA01MCC",
@@ -47627,7 +47627,7 @@
     ]
   },
   {
-    "systemNumber": "10000099",
+    "systemNumber": "90000027",
     "vin": "AUTOQAMCYCLE00002",
     "partialVin": "E00002",
     "primaryVrm": "QA02MCC",
@@ -47667,7 +47667,7 @@
     ]
   },
   {
-    "systemNumber": "10000101",
+    "systemNumber": "90000028",
     "vin": "AUTOQAMCYCLE00003",
     "partialVin": "E00003",
     "primaryVrm": "QA03MCC",
@@ -47707,7 +47707,7 @@
     ]
   },
   {
-    "systemNumber": "10000102",
+    "systemNumber": "90000029",
     "vin": "AUTOQAMCYCLE00004",
     "partialVin": "E00004",
     "primaryVrm": "QA04MCC",
@@ -47747,7 +47747,7 @@
     ]
   },
   {
-    "systemNumber": "10000103",
+    "systemNumber": "90000030",
     "vin": "AUTOQAMCYCLE00005",
     "partialVin": "E00005",
     "primaryVrm": "QA05MCC",
@@ -47787,7 +47787,7 @@
     ]
   },
   {
-    "systemNumber": "10000104",
+    "systemNumber": "90000031",
     "vin": "AUTOQAMCYCLE00006",
     "partialVin": "E00006",
     "primaryVrm": "QA06MCC",


### PR DESCRIPTION
## UI Auto Update Seed Data

QA has been requested by VTM to change the system numbers and advised to start each number with a 9 i.e. 90000001 to differentiate from VTM.
[link to ticket number](https://dvsa.atlassian.net/browse/VTA-1492)

## Checklist

- [x] Code has been tested manually
- [x] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number
